### PR TITLE
Log LLM transcripts into repository artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: docs-api docs-validate
+
+DOCS_SPEC=docs/integration/API_CONTRACTS.yaml
+DOCS_OUTPUT=docs/integration/api.html
+
+## Generate static HTML documentation from the OpenAPI contract
+## Requires Node.js (`npx @redocly/cli`)
+docs-api:
+	npx @redocly/cli build-docs $(DOCS_SPEC) -o $(DOCS_OUTPUT)
+
+## Validate that FastAPI exposes the same schema as the contract
+docs-validate:
+	REDIS_URL=redis://localhost:6379/0 \
+	DB_PATH=./data/validate-openapi.db uv run python scripts/validate_openapi.py

--- a/app/agents/cto.py
+++ b/app/agents/cto.py
@@ -20,7 +20,7 @@ class CTOAgent:
 
     async def create_plan(
         self, task: str, *, messages: List[Dict[str, str]] | None = None
-    ) -> tuple[List[Dict[str, str]], int, int]:
+    ) -> tuple[List[Dict[str, str]], int, int, str]:
         if messages is None:
             context = f"Task: {task}"
             section = self.spec.section("CTO-AI")
@@ -39,12 +39,12 @@ class CTOAgent:
                     "files": [],
                     "commands": [],
                 }
-            ], response.tokens_in, response.tokens_out)
+            ], response.tokens_in, response.tokens_out, plan_text)
         try:
             plan = json.loads(plan_text)
             if not isinstance(plan, list):
                 raise ValueError("Plan must be a list")
-            return plan, response.tokens_in, response.tokens_out
+            return plan, response.tokens_in, response.tokens_out, plan_text
         except json.JSONDecodeError as exc:
             logger.error("cto_plan_parse_error", error=str(exc), response=plan_text)
             raise

--- a/app/core/llm_logging.py
+++ b/app/core/llm_logging.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+LOG_SUBDIR = ".autodev"
+LOG_FILENAME = "llm_calls.jsonl"
+
+
+def _ensure_timestamp(entry: Dict[str, Any]) -> Dict[str, Any]:
+    if "timestamp" not in entry or not entry.get("timestamp"):
+        entry = {**entry, "timestamp": datetime.now(timezone.utc).isoformat()}
+    return entry
+
+
+def append_llm_log(base_path: Path, entry: Dict[str, Any]) -> Path:
+    """Append a single LLM call transcript to the log file."""
+
+    log_dir = Path(base_path) / LOG_SUBDIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / LOG_FILENAME
+    payload = _ensure_timestamp(entry)
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False))
+        handle.write("\n")
+    return log_file
+
+
+def append_llm_logs(base_path: Path, entries: Iterable[Dict[str, Any]]) -> Optional[Path]:
+    log_file: Optional[Path] = None
+    for entry in entries:
+        log_file = append_llm_log(base_path, entry)
+    return log_file
+
+
+@dataclass
+class LLMTranscriptRecorder:
+    """Buffers LLM transcripts until a repository path is available."""
+
+    base_path: Optional[Path] = None
+    _buffer: List[Dict[str, Any]] = field(default_factory=list)
+
+    def set_base_path(self, base_path: Path) -> None:
+        self.base_path = Path(base_path)
+        self.flush()
+
+    def record(self, entry: Dict[str, Any]) -> None:
+        self._buffer.append(entry)
+        self.flush()
+
+    def flush(self) -> None:
+        if self.base_path is None or not self._buffer:
+            return
+        append_llm_logs(self.base_path, self._buffer)
+        self._buffer.clear()

--- a/docs/architecture/SYSTEM_OVERVIEW.md
+++ b/docs/architecture/SYSTEM_OVERVIEW.md
@@ -1,0 +1,90 @@
+# System Overview
+
+## Context Diagram (C4 Level 1)
+
+```mermaid
+C4Context
+    title Auto Dev Orchestrator – Context Diagram
+    Person(client, "Delivery Engineer", "Plant Jobs, beobachtet Fortschritt und verwaltet Modelle")
+    Person(github, "GitHub", "Quelle für Repositories und Pull-Requests")
+    System_Boundary(system, "Auto Dev Orchestrator Platform") {
+        System(back_api, "FastAPI Backend", "Plant, überwacht und orchestriert Jobs")
+        System(frontend, "React Dashboard", "Visualisiert Jobs, Einstellungen und Dateibrowser")
+        System(gradio, "Gradio UI", "Alternative UI für interaktive Steuerung")
+    }
+    System_Ext(redis, "Redis", "Message Broker für Celery und Job-Events")
+    System_Ext(sqlite, "SQL Database", "Persistente Ablage für Jobs, Kosten, Memory und Kontext")
+    System_Ext(llm, "LLM Provider", "OpenAI/Ollama für CTO-, Coder- und Custom-Agenten")
+    Rel(client, frontend, "Verwaltet Jobs & Einstellungen")
+    Rel(client, gradio, "Startet Jobs & überwacht Ergebnisse")
+    Rel(frontend, back_api, "REST & WebSocket Requests")
+    Rel(gradio, back_api, "REST API Calls")
+    Rel(back_api, redis, "Celery Tasks & Pub/Sub Events")
+    Rel(back_api, sqlite, "ORM Persistenz über SQLAlchemy")
+    Rel(back_api, llm, "LLM Prompts & Kosten-Tracking")
+    Rel(back_api, github, "Repo- und PR-Operations")
+```
+
+## Container Diagram (C4 Level 2)
+
+```mermaid
+C4Container
+    title Auto Dev Orchestrator – Container Diagram
+    Person(client, "Delivery Engineer")
+    System_Boundary(system, "Auto Dev Orchestrator Platform") {
+        Container(api, "FastAPI Service", "Python/FastAPI", "REST API, WebSocket, Settings, Task-Enqueue")
+        Container(worker, "Celery Worker", "Python/Celery", "Führt CTO-, Coder- und Integrationsschritte aus")
+        Container(frontend, "React Dashboard", "TypeScript/Vite", "Job Monitoring, Settings, File Browser")
+        Container(gradio, "Gradio UI", "Python/Gradio", "Alternative UI für Rapid Demos")
+        ContainerDb(sqlite, "SQL Database", "SQLite", "Jobs, Steps, Kosten, Memory, Context Metrics")
+        Container(redis, "Redis", "Redis", "Broker für Celery & Pub/Sub für Job Events")
+    }
+    System_Ext(llm, "LLM Provider APIs", "OpenAI, Claude, kundenspezifische Modelle")
+    System_Ext(github, "GitHub API", "Repos & Pull Requests")
+
+    Rel(client, frontend, "HTTP/WebSocket")
+    Rel(client, gradio, "HTTP")
+    Rel(frontend, api, "REST/JSON, WebSocket Events")
+    Rel(gradio, api, "REST/JSON")
+    Rel(api, worker, "Celery Queue über Redis")
+    Rel(api, sqlite, "SQLAlchemy ORM")
+    Rel(worker, sqlite, "SQLAlchemy ORM")
+    Rel(api, redis, "Pub/Sub job-events")
+    Rel(worker, redis, "Publish job events")
+    Rel(worker, llm, "LLM Prompting & Kostenmessung")
+    Rel(worker, github, "Repo Sync, Branches, PRs")
+```
+
+## Architektur-Hauptpunkte
+
+- **Domänenorientierung:** Die Plattform folgt einem Domain-Driven-Design-Ansatz mit Kernfokus auf der *Orchestration*-Domäne. Erweiterbare Domänen für Authentifizierung und Billing sind bereits vorgesehen.
+- **Multi-Agent-Orchestrierung:** Die CTO-, Coder-, CustomCoder-, ClaudeCode- und Codex-Agenten koordinieren sich über den Agent Router. Informationen zur Agentenlandschaft stammen aus `AGENTS.md` und werden beim Start eingelesen.
+- **Event-getriebene Transparenz:** Jobstatus und Kostenupdates werden über Redis Pub/Sub verteilt und über WebSockets in Frontends angezeigt.
+- **Konfigurierbarkeit & Guardrails:** Settings-API und Environment-Management stellen sicher, dass Model- und Budgetgrenzen dynamisch angepasst werden können. Budget Guards sind zentral im Healthcheck einsehbar.
+
+## Laufzeitfluss (High-Level)
+
+1. **Task-Anlage:** Ein:e Engineer:in oder die UI erstellt über `/tasks` einen neuen Job. Der Backend-Service persistiert den Job, legt Budgetlimits fest und übergibt die Arbeit an den Celery-Worker.
+2. **Planning:** Der CTO-Agent erzeugt Step-Pläne, wobei `AGENTS.md` als Policies dient. Ergebnisse werden in der Datenbank gespeichert.
+3. **Execution:** Der Agent Router weist Schritte geeigneten Agents zu. Der Coder-Agent erstellt Diffs, führt Tests aus und aktualisiert Jobkosten.
+4. **Events & Monitoring:** Fortschritt, Kosten und Kontextmetriken werden kontinuierlich in der Datenbank protokolliert und über Redis `job-events` an verbundene Clients gestreamt.
+5. **Completion:** Sobald alle Steps abgeschlossen sind, aktualisiert das System den Jobstatus, erstellt optional Pull Requests und signalisiert Abschlussereignisse.
+
+## Nicht-funktionale Anforderungen
+
+- **Stabilität:** Start-up Hooks bauen Datenbankschemata automatisch auf und verhindern fehlende Agentenspezifikationen.
+- **Transparenz:** Kosten-Tracking pro Agent und Rolling-Averages für Performance (siehe `AGENTS.md`).
+- **Skalierbarkeit:** API- und Worker-Container können unabhängig horizontal skaliert werden; Redis dient als shared broker.
+- **Compliance & Sicherheit:** Secrets werden über Settings-API verwaltet, Dateibrowser hat Pfad-Sandboxing und Memory Store erzwingt Limits.
+
+## Schnittstellen
+
+- **REST API:** Siehe `docs/integration/API_CONTRACTS.yaml` für formale Contracts.
+- **WebSocket:** Echtzeit-Events unter `ws://<host>/ws/jobs`.
+- **Dateisystem:** Sandbox unter `./data` für temporäre Artefakte.
+
+## Offene Fragen & Erweiterungen
+
+- **Auth-System:** Zukünftige Integration eines dedizierten AuthN/AuthZ-Services (siehe Domain-Placeholder & Playbook).
+- **Billing-Integration:** Erweiterung der Kostenmodelle um provider-spezifische Abrechnung und Export nach externen Systemen.
+- **Model Governance:** Ausbau der Settings-API um Modellparameter, Rate Limits und Audit Trails.

--- a/docs/architecture/decisions/0001-use-fastapi-for-orchestration.md
+++ b/docs/architecture/decisions/0001-use-fastapi-for-orchestration.md
@@ -1,0 +1,24 @@
+# ADR 0001: Use FastAPI for the orchestration service
+
+- **Status:** accepted
+- **Date:** 2024-09-18
+- **Decision Makers:** Platform Architecture Guild
+- **Related Requirements:** Stable REST API, async-ready worker coordination
+
+## Context
+
+Wir benötigen einen Backend-Service, der REST- und WebSocket-Endpunkte bereitstellt, Celery-Worker orchestriert und dynamische Einstellungen handhabt. Das System muss mit modernen Python-Versionen harmonieren, asynchrones I/O unterstützen und eine klare OpenAPI-Schnittstelle erzeugen. Alternativen wie Flask oder Django würden zusätzliche Libraries bzw. monolithische Strukturen erfordern.
+
+## Decision
+
+Wir setzen FastAPI als zentrale Web-Schicht ein. FastAPI stellt automatische OpenAPI-Generierung bereit, integriert sich nahtlos mit Pydantic 2.x und unterstützt asynchrone Endpunkte für WebSockets und Streaming. Die bestehende Codebasis (`app/main.py`, `app/routers/*`) nutzt bereits FastAPI-Routerstrukturen.
+
+## Consequences
+
+- **Positiv:** Schnelle Entwicklung von typisierten Endpunkten, native OpenAPI-Spezifikation und Kompatibilität mit modernem Python.
+- **Negativ:** Höhere Lernkurve für Teammitglieder ohne Erfahrung mit Pydantic 2.x oder async Patterns.
+
+## Alternatives Considered
+
+1. **Flask + Flask-RESTX** – würde mehr Boilerplate für Typisierung und async Support erfordern.
+2. **Django REST Framework** – schwergewichtiger für den Microservice-Charakter, benötigt eigene ORM/Settings-Struktur.

--- a/docs/architecture/decisions/0002-adopt-multi-agent-orchestration.md
+++ b/docs/architecture/decisions/0002-adopt-multi-agent-orchestration.md
@@ -1,0 +1,24 @@
+# ADR 0002: Adopt a multi-agent orchestration model
+
+- **Status:** accepted
+- **Date:** 2024-09-18
+- **Decision Makers:** Platform Architecture Guild
+- **Related Requirements:** Kostenkontrolle, Spezialisierbare Workflows, Resilienz
+
+## Context
+
+Die Roadmap fordert skalierbare Automatisierung mit unterschiedlichen Qualitäts- und Kostenniveaus. Ein einziger LLM-Agent konnte entweder die Qualitäts- oder Kostenanforderungen nicht erfüllen. Unsere Policy-Datei `AGENTS.md` beschreibt bereits klare Rollen (CTO, Coder, CustomCoder, ClaudeCode, Codex) und deren Interaktionen.
+
+## Decision
+
+Wir etablieren einen Router, der Aufgaben anhand von Komplexität, Budget und Profilzuordnung auf spezialisierte Agents verteilt. Jeder Agent implementiert das `BaseAgent`-Interface und kann unabhängig skaliert und ausgetauscht werden. Redis Pub/Sub unterstützt Fallback-Mechanismen, und Kosten werden pro Agent nachverfolgt.
+
+## Consequences
+
+- **Positiv:** Verbesserte Qualität durch Spezialisierung, flexibel skalierbare Kostenprofile, robuste Fallbacks.
+- **Negativ:** Höhere Komplexität beim Betrieb (mehr Services, Monitoring-Aufwand) und erhöhter Bedarf an klarer Dokumentation.
+
+## Alternatives Considered
+
+1. **Single-Agent-Architektur** – scheiterte an Budget- und Spezialisierungsanforderungen.
+2. **Externes Orchestrierungstool** – hätte zusätzliche Latenz und Integrationsaufwand erzeugt, ohne direkten Nutzen für unsere Agent-Policies.

--- a/docs/architecture/decisions/ADR_TEMPLATE.md
+++ b/docs/architecture/decisions/ADR_TEMPLATE.md
@@ -1,0 +1,24 @@
+# {ADR_TITLE}
+
+- **Status:** {proposed|accepted|deprecated|superseded}
+- **Date:** {YYYY-MM-DD}
+- **Decision Makers:** {Team or people}
+- **Related Requirements:** {Links to tickets, OKRs, docs}
+
+## Context
+
+{What problem are we solving? Welche Kräfte wirken?}
+
+## Decision
+
+{Kurzbeschreibung der gewählten Lösung.}
+
+## Consequences
+
+- {Positive Folge}
+- {Negative Folge}
+
+## Alternatives Considered
+
+1. {Alternative 1} – {warum verworfen}
+2. {Alternative 2} – {warum verworfen}

--- a/docs/domains/authentication/README.md
+++ b/docs/domains/authentication/README.md
@@ -1,0 +1,30 @@
+# Authentication Domain
+
+## Purpose
+- Bereitet eine zukünftige Identitäts- und Zugriffsverwaltung vor.
+- Ziel ist es, API-Zugriffe, UI-Sessions und Service-to-Service-Kommunikation zu schützen.
+
+## Boundaries
+- Wird Log-in-/Token-Flows, Rollenmodelle und Audit-Trails abdecken.
+- Abhängigkeiten zu Orchestration (Jobberechtigungen) und Billing (kontingentbasierte Limits) werden definiert.
+- Aktuell keine Implementierung im Code; dieses Dokument dient als Design-Placeholder.
+
+## API
+- Noch nicht implementiert. Erwartete Endpunkte:
+  - `POST /auth/login` für Session Tokens.
+  - `POST /auth/refresh` für Token-Rotation.
+  - `GET /auth/profile` für Rolleninformationen.
+
+## Dependencies
+- Identity Provider (z. B. OAuth2/OIDC) oder Self-Managed User Store.
+- Secrets-Management zur sicheren Speicherung von Client-IDs/Secrets.
+
+## Integration Points
+- Frontend: UI-Gating für Dashboard und Settings.
+- Backend: FastAPI Dependencies für AuthN/AuthZ.
+- Worker: Zugriffsbeschränkung für externe Integrationen.
+
+## Extension Points
+- Policy-Engine (z. B. OPA) für fein-granulare Berechtigungen.
+- Audit-Logging-Schnittstelle für Security-Teams.
+- Hooks für Webhooks/SCIM zur Benutzerprovisionierung.

--- a/docs/domains/billing/README.md
+++ b/docs/domains/billing/README.md
@@ -1,0 +1,30 @@
+# Billing Domain
+
+## Purpose
+- Plant eine spätere Abrechnungsschicht für Agenten- und Infrastrukturkosten.
+- Ziel ist Kosten-Transparenz pro Kunde, Projekt und Agent bereitzustellen.
+
+## Boundaries
+- Wird Kostendaten aus `cost_entries` aggregieren und mit Provider-Raten (OpenAI, Claude, etc.) korrelieren.
+- Budget-Limits aus Orchestration dienen als Input, Auth liefert Zuordnung zu Konten/Teams.
+- Aktuell nicht umgesetzt; fungiert als Dokumentationsanker für zukünftige Entwicklung.
+
+## API
+- Geplante Services:
+  - `GET /billing/statements` für periodische Reports.
+  - `POST /billing/allocations` zur Budgetzuordnung.
+  - `GET /billing/providers` für Kostenmodelle.
+
+## Dependencies
+- Pricing-Datenquelle (`pricing.json` und Settings-API).
+- Externe Abrechnungssysteme oder ERP-Schnittstellen.
+- Datenbankerweiterungen für Rechnungen und Buchungssätze.
+
+## Integration Points
+- Orchestration Domain: konsumiert Budgetwarnungen und liefert Kosten-Einzelposten.
+- Finance Tools: Export als CSV/JSON, Webhooks für Accounting.
+
+## Extension Points
+- Multi-Währungsunterstützung.
+- Usage-basiertes Alerting (PagerDuty, Slack, E-Mail).
+- Automatisierte Chargeback-Berechnung pro Team.

--- a/docs/domains/orchestration/README.md
+++ b/docs/domains/orchestration/README.md
@@ -1,0 +1,36 @@
+# Orchestration Domain
+
+## Purpose
+- Automatisiert Planung, Ausführung und Überwachung von Software-Lieferjobs.
+- Koordiniert CTO-, Coder- und Spezial-Agenten entlang von Budget- und Policy-Vorgaben.
+- Stellt REST- und Event-Schnittstellen für Frontends und externe Integrationen bereit.
+
+## Boundaries
+- Umfasst Job- und Step-Management (`jobs`, `job_steps`, `cost_entries`).
+- Verwaltet Memory, Kontextdokumente und Dateiuploads für laufende Jobs.
+- Exkludiert Benutzeridentität (Auth) und abrechnungsrelevante Aggregationen (Billing).
+
+## API
+- `POST /tasks` legt neue Jobs inkl. Budgetgrenzen an.
+- `GET /jobs`, `GET /jobs/{id}`, `POST /jobs/{id}/cancel`, `GET /jobs/{id}/context` zur Laufzeitsteuerung.
+- `POST /context/docs` importiert Wissensdokumente.
+- `GET/POST /memory/{job_id}` Endpunkte für Notizen und Files.
+- `GET /api/env`, `PUT /api/env/{key}`, `GET /api/models`, `PUT /api/models/{model}` zur Konfiguration.
+
+## Dependencies
+- **LLM Providers:** OpenAI und weitere über `app/llm` (Modellauswahl aus Settings).
+- **Celery & Redis:** Queueing für Planungs-/Ausführungsschritte und Event-Streaming.
+- **SQL Database:** Persistenz der Job- und Kosten-Entities.
+- **Git Integrationen:** GitHub-API via `app/git` für Repo-Operationen.
+
+## Integration Points
+- React Dashboard (`frontend/`) konsumiert REST- und WebSocket-Endpunkte.
+- Gradio UI (`webui/`) nutzt dieselben APIs für manuelle Steuerung.
+- Externe Systeme können über WebSocket `ws://<host>/ws/jobs` den Jobstatus abonnieren.
+- Settings-API erlaubt Automatisierungstools, Modelle und Secrets zentral zu pflegen.
+
+## Extension Points
+- Neue Agents implementieren `BaseAgent` und werden im Router registriert.
+- Zusatz-Router können via FastAPI hinzugefügt werden (`app/routers`).
+- Kontext-Provider (Embeddings) lassen sich über `app/embeddings` austauschen.
+- Job-Lifecycle Hooks über Celery Tasks oder Signals erweiterbar.

--- a/docs/integration/API_CONTRACTS.yaml
+++ b/docs/integration/API_CONTRACTS.yaml
@@ -1,0 +1,921 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Auto Dev Orchestrator API",
+    "version": "1.0.0",
+    "description": "Formal API contract f\u00fcr das FastAPI-Backend."
+  },
+  "servers": [
+    {
+      "url": "https://api.auto-dev.local"
+    }
+  ],
+  "paths": {
+    "/health/": {
+      "get": {
+        "summary": "System health",
+        "responses": {
+          "200": {
+            "description": "Service healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service degraded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tasks": {
+      "post": {
+        "summary": "Create orchestration job",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaskCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Job enqueued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskCreateResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/jobs/{job_id}": {
+      "get": {
+        "summary": "Get job",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          }
+        }
+      }
+    },
+    "/jobs/{job_id}/cancel": {
+      "post": {
+        "summary": "Cancel job",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Cancellation confirmed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "cancelled"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found"
+          }
+        }
+      }
+    },
+    "/jobs/{job_id}/context": {
+      "get": {
+        "summary": "Get latest context diagnostics",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Context metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContextDiagnosticsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Context diagnostics not found"
+          }
+        }
+      }
+    },
+    "/context/docs": {
+      "post": {
+        "summary": "Ingest contextual document",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContextDocRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Document stored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContextDocResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid document"
+          }
+        }
+      }
+    },
+    "/memory/{job_id}": {
+      "get": {
+        "summary": "Get memory notes and files",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memory snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/memory/{job_id}/notes": {
+      "post": {
+        "summary": "Create memory note",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemoryNoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Note stored"
+          },
+          "400": {
+            "description": "Limit exceeded or invalid payload"
+          }
+        }
+      }
+    },
+    "/memory/{job_id}/files": {
+      "post": {
+        "summary": "Upload memory file",
+        "parameters": [
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "File stored",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemoryFileResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Upload failed"
+          },
+          "503": {
+            "description": "Multipart dependency missing"
+          }
+        }
+      }
+    },
+    "/api/env": {
+      "get": {
+        "summary": "List environment variables",
+        "responses": {
+          "200": {
+            "description": "Variables",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EnvVariable"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/env/{key}": {
+      "put": {
+        "summary": "Update environment variable",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnvUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated variable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnvVariable"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown variable"
+          }
+        }
+      }
+    },
+    "/api/models": {
+      "get": {
+        "summary": "List model configurations",
+        "responses": {
+          "200": {
+            "description": "Model configs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ModelConfig"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/models/{model_id}": {
+      "put": {
+        "summary": "Update model configuration",
+        "parameters": [
+          {
+            "name": "model_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated configuration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelConfig"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unknown model"
+          }
+        }
+      }
+    },
+    "/api/files": {
+      "get": {
+        "summary": "List sandbox files",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "/"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileEntry"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Path not found"
+          }
+        }
+      }
+    },
+    "/ws/jobs": {
+      "get": {
+        "summary": "WebSocket handshake for job events",
+        "description": "Clients m\u00fcssen nach erfolgreichem HTTP-Handshake auf WebSocket upgraden und erhalten JSON-Events vom Typ job.*.",
+        "responses": {
+          "101": {
+            "description": "Switching protocols"
+          }
+        }
+      },
+      "x-kind": "websocket"
+    },
+    "/jobs/": {
+      "get": {
+        "summary": "List jobs",
+        "responses": {
+          "200": {
+            "description": "List of jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/JobResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "db": {
+            "type": "boolean"
+          },
+          "redis": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string"
+          },
+          "budgetGuard": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "service": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "TaskCreateRequest": {
+        "type": "object",
+        "required": [
+          "task",
+          "repo_owner",
+          "repo_name",
+          "branch_base",
+          "budgetUsd",
+          "maxRequests",
+          "maxMinutes"
+        ],
+        "properties": {
+          "task": {
+            "type": "string"
+          },
+          "repo_owner": {
+            "type": "string"
+          },
+          "repo_name": {
+            "type": "string"
+          },
+          "branch_base": {
+            "type": "string"
+          },
+          "budgetUsd": {
+            "type": "number",
+            "minimum": 0
+          },
+          "maxRequests": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxMinutes": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "modelCTO": {
+            "type": "string",
+            "nullable": true
+          },
+          "modelCoder": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "TaskCreateResponse": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "job_id"
+        ]
+      },
+      "JobStepResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "JobResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "task": {
+            "type": "string"
+          },
+          "repo_owner": {
+            "type": "string"
+          },
+          "repo_name": {
+            "type": "string"
+          },
+          "branch_base": {
+            "type": "string"
+          },
+          "budget_usd": {
+            "type": "number"
+          },
+          "max_requests": {
+            "type": "integer"
+          },
+          "max_minutes": {
+            "type": "integer"
+          },
+          "cost_usd": {
+            "type": "number"
+          },
+          "tokens_in": {
+            "type": "integer"
+          },
+          "tokens_out": {
+            "type": "integer"
+          },
+          "requests_made": {
+            "type": "integer"
+          },
+          "progress": {
+            "type": "number"
+          },
+          "last_action": {
+            "type": "string",
+            "nullable": true
+          },
+          "pr_links": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "model_cto": {
+            "type": "string",
+            "nullable": true
+          },
+          "model_coder": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ContextDiagnosticsResponse": {
+        "type": "object",
+        "properties": {
+          "job_id": {
+            "type": "string"
+          },
+          "step_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "tokens_final": {
+            "type": "integer"
+          },
+          "tokens_clipped": {
+            "type": "integer"
+          },
+          "compact_ops": {
+            "type": "integer"
+          },
+          "budget": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "dropped": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "hints": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ContextDocRequest": {
+        "type": "object",
+        "required": [
+          "title",
+          "text"
+        ],
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "ContextDocResponse": {
+        "type": "object",
+        "properties": {
+          "ref_id": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string",
+            "example": "doc"
+          }
+        }
+      },
+      "MemoryResponse": {
+        "type": "object",
+        "properties": {
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "MemoryNoteRequest": {
+        "type": "object",
+        "required": [
+          "type",
+          "title",
+          "body"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stepId": {
+            "type": "string"
+          }
+        }
+      },
+      "MemoryFileResponse": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "bytes": {
+            "type": "integer"
+          }
+        }
+      },
+      "EnvVariable": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "is_secret": {
+            "type": "boolean"
+          }
+        }
+      },
+      "EnvUpdateRequest": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "ModelVariant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "ModelConfig": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelVariant"
+            }
+          },
+          "selectedVariant": {
+            "type": "string",
+            "nullable": true
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ModelUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "selectedVariant": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "FileEntry": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "file",
+              "directory"
+            ]
+          },
+          "size": {
+            "type": "integer"
+          },
+          "modifiedAt": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/integration/DATABASE_SCHEMA.md
+++ b/docs/integration/DATABASE_SCHEMA.md
@@ -1,0 +1,135 @@
+# Database Schema
+
+Die Plattform nutzt SQLAlchemy mit SQLite (Standard) bzw. kompatiblen RDBMS. Das Schema wird bei Start von `app.main` automatisch erzeugt.
+
+```mermaid
+erDiagram
+    JOBS ||--o{ JOB_STEPS : contains
+    JOBS ||--o{ COST_ENTRIES : tracks
+    JOBS ||--o{ MEMORY_ITEMS : stores
+    JOBS ||--o{ MEMORY_FILES : stores
+    JOBS ||--o{ MESSAGE_SUMMARIES : summarizes
+    JOBS ||--o{ CONTEXT_METRICS : records
+    JOBS {
+        string id PK
+        string task
+        string repo_owner
+        string repo_name
+        string branch_base
+        string status
+        float budget_usd
+        int max_requests
+        int max_minutes
+        string model_cto
+        string model_coder
+        float cost_usd
+        int tokens_in
+        int tokens_out
+        int requests_made
+        datetime started_at
+        datetime finished_at
+        boolean cancelled
+        string last_action
+        json pr_links
+        string agents_hash
+        datetime created_at
+        datetime updated_at
+    }
+    JOB_STEPS {
+        string id PK
+        string job_id FK
+        string name
+        string step_type
+        string status
+        text details
+        datetime started_at
+        datetime finished_at
+        datetime created_at
+    }
+    COST_ENTRIES {
+        string id PK
+        string job_id FK
+        string provider
+        string model
+        int tokens_in
+        int tokens_out
+        float cost_usd
+        datetime created_at
+    }
+    MEMORY_ITEMS {
+        string id PK
+        string job_id FK
+        string kind
+        string key
+        text content
+        datetime created_at
+        datetime updated_at
+    }
+    MEMORY_FILES {
+        string id PK
+        string job_id FK
+        string path
+        binary bytes
+        datetime created_at
+    }
+    MESSAGE_SUMMARIES {
+        string id PK
+        string job_id FK
+        string step_id
+        string role
+        text summary
+        int tokens
+        datetime created_at
+    }
+    EMBEDDING_INDEX {
+        string id PK
+        string scope
+        string ref_id
+        text text
+        json vector
+        datetime created_at
+    }
+    CONTEXT_METRICS {
+        string id PK
+        string job_id FK
+        string step_id
+        int tokens_final
+        int tokens_clipped
+        int compact_ops
+        json details
+        datetime created_at
+    }
+```
+
+## Table Details
+
+### jobs
+- Persistiert Job-Metadaten und Budgetgrenzen (Quelle: `app/db/models.py`).
+- `agents_hash` verknüpft Jobs mit der verwendeten `AGENTS.md`-Version.
+- `pr_links` enthält generierte Pull-Request-URLs.
+
+### job_steps
+- Speichert die Einzelschritte eines Jobs und deren Status (`planned`, `running`, `completed`, etc.).
+- Dient als Grundlage für Fortschrittsberechnung und Event-Emission.
+
+### cost_entries
+- Trackt Token- und Kostenwerte pro Agent-Aufruf.
+- Grundlage für spätere Billing-Aggregationen.
+
+### memory_items
+- JSON-basierte Notizen (`notes`) für Structured Memory.
+- Unterstützt Guardrails via `MemoryStore` (Limits, Tags).
+
+### memory_files
+- Binäre Artefakte, die Uploads aus `/memory/{job_id}/files` ablegen.
+- Pfade referenzieren Sandbox-Verzeichnis `./data`.
+
+### message_summaries
+- Persistiert agentenseitige Nachrichten-Zusammenfassungen für Auditing.
+
+### embedding_index
+- Speichert Embeddings für Kontextdokumente (Scope `doc`, `memory`, ...).
+- Interagiert mit `EmbeddingStore` und OpenAI-Provider.
+
+### context_metrics
+- Bewahrt Kontextdiagnosen (Tokens, Kompressionsoperationen) für die UI.

--- a/docs/integration/EVENTS.md
+++ b/docs/integration/EVENTS.md
@@ -1,0 +1,53 @@
+# Event Streams
+
+Job-bezogene Ereignisse werden über Redis Pub/Sub (`job-events`) verteilt und über den WebSocket-Endpunkt `/ws/jobs` ausgespielt. Alle Nachrichten besitzen folgende Grundstruktur:
+
+```json
+{
+  "type": "job.updated",
+  "payload": {
+    "id": "<job-id>",
+    "status": "running",
+    "task": "...",
+    "repo_owner": "...",
+    "repo_name": "...",
+    "branch_base": "main",
+    "budget_usd": 50.0,
+    "max_requests": 30,
+    "max_minutes": 45,
+    "model_cto": "gpt-4o-mini-plan",
+    "model_coder": "gpt-4o-coder",
+    "cost_usd": 3.2,
+    "tokens_in": 4500,
+    "tokens_out": 3200,
+    "requests_made": 4,
+    "progress": 0.66,
+    "last_action": "plan",
+    "pr_links": ["https://github.com/org/repo/pull/123"],
+    "created_at": "2024-09-18T10:15:00Z",
+    "updated_at": "2024-09-18T10:25:00Z"
+  }
+}
+```
+
+## Event Types
+
+| Event            | Auslöser                                                   | Hinweise |
+|------------------|------------------------------------------------------------|----------|
+| `job.created`    | `/tasks` legt neuen Job an                                  | Payload enthält initiale Budget-/Repo-Daten. |
+| `job.updated`    | Statusänderung, Step-Fortschritt, Kostenupdate (`execute_job`) | `progress` berechnet Completed Steps / Total Steps. |
+| `job.cancelled`  | `/jobs/{id}/cancel` markiert Job als abgebrochen             | Konsumenten sollten laufende Anzeigen schließen. |
+| `job.completed`  | Alle Steps erfolgreich abgeschlossen, optional PR erstellt   | Letzte Aktion (`last_action`) gibt finalen Step an. |
+| `job.failed`     | Fehler im Worker, Budget überschritten oder Hard-Failure    | Folgeaktionen: Incident-Workflow, Alerting. |
+
+## Konsum über WebSocket
+
+1. Öffne WebSocket-Verbindung zu `ws://<host>/ws/jobs`.
+2. Nach `101 Switching Protocols` liefert der Server JSON-Nachrichten wie oben.
+3. Verbindung wird serverseitig geschlossen, wenn Redis oder Worker nicht verfügbar ist. Client sollte automatische Reconnects implementieren.
+
+## Fehlertoleranz
+
+- Bei JSON-Parsing-Fehlern im Pub/Sub-Stream wird das Ereignis verworfen, der Stream bleibt aktiv (`job_event_decode_failed`).
+- Redis-Verbindungsfehler werden geloggt; Clients sehen ggf. keine neuen Events bis zum Reconnect.
+- `payload.pr_links` kann leer sein, wenn kein Pull Request erzeugt wurde.

--- a/docs/playbooks/add-new-agent.md
+++ b/docs/playbooks/add-new-agent.md
@@ -1,0 +1,32 @@
+# Playbook: Add a new agent
+
+## Preconditions
+- Neues Agentenprofil (Use-Case, Budget, Modell) ist abgestimmt.
+- Zugang zu LLM-Provider oder Custom-Backend vorhanden.
+- Test- und Observability-Plan definiert.
+
+## Steps
+1. **Agent Skeleton erstellen**
+   - Lege Datei `app/agents/<agent_name>.py` an.
+   - Implementiere Klasse, die `BaseAgent` erfüllt (`plan`, `execute`, `estimate_cost`).
+2. **Router registrieren**
+   - Ergänze `AGENT_TYPES` in `app/agents/__init__.py`.
+   - Aktualisiere `app/router/agent_router.py` mit Dispatch-Regeln (Komplexität, Budget, Profile).
+3. **Settings & Policies**
+   - Ergänze `AGENTS.md` um Beschreibung, Kostencharakteristik und Fallbacks.
+   - Optional: Settings-API um Modellvarianten erweitern (`_MODEL_DEFINITIONS`).
+4. **Tests schreiben**
+   - Unit Tests in `tests/agents/test_<agent_name>.py`.
+   - Routing-Test in `tests/router/test_routing.py` (neue Branches).
+   - Führt `uv run pytest` aus.
+5. **Worker überprüfen**
+   - Dry-Run via `scripts/run_agent.py --agent <agent_name> --job <job_id>`.
+   - Logging-Level temporär auf Debug setzen (`LOG_LEVEL=DEBUG`).
+6. **Deployment**
+   - Rollout in Staging, verifiziere WebSocket-Events (`job.updated`).
+   - Update `docs/architecture/SYSTEM_OVERVIEW.md` falls neue Container benötigt werden.
+
+## Rollback
+- Entferne den Agenten aus Router und Settings.
+- Lösche Klassendatei und Tests.
+- Re-deploy Worker, prüfe, ob Standard-Routing funktioniert.

--- a/docs/playbooks/add-new-llm-model.md
+++ b/docs/playbooks/add-new-llm-model.md
@@ -1,0 +1,30 @@
+# Playbook: Add a new LLM model
+
+## Preconditions
+- Pricing-Eintrag in `pricing.json` oder externer Quelle vorhanden.
+- API-Key und Provider-spezifische Zugangsdaten verfügbar.
+- Tests (`uv run pytest`) laufen lokal.
+
+## Steps
+1. **Pricing aktualisieren**
+   - Ergänze `pricing.json` um Tarifinformationen (`prompt`, `completion`, `currency`).
+   - Falls neues Preismodell erforderlich ist, aktualisiere `app/core/pricing.py`.
+2. **Settings-API erweitern**
+   - Füge das Modell als Variant in `docs/integration/API_CONTRACTS.yaml` (`ModelVariant`) hinzu, wenn API-Kunden es sehen sollen.
+   - Stelle sicher, dass `get_pricing_table()` das Modell zurückliefert.
+3. **Environment Defaults setzen**
+   - Aktualisiere `.env.example` mit neuem Default (falls erforderlich).
+   - Verwende `PUT /api/models/{model}` oder `make docs-validate` nach Anpassung der Spezifikation.
+4. **Provider Implementation**
+   - Implementiere ggf. neue Klasse in `app/llm/` (z. B. `my_provider.py`).
+   - Registriere sie im Agent Router oder in den Settings.
+5. **Tests & Validierung**
+   - Führe `uv run pytest tests` aus.
+   - Optional: Smoke-Test via `scripts/run_agent.py --agent coder --model <model>`.
+6. **Dokumentation**
+   - Aktualisiere `AGENTS.md` mit Kostencharakteristik.
+   - Ergänze Release Notes.
+
+## Rollback
+- Entferne den Pricing-Eintrag und setze Modell-Env-Wert auf vorherige Variante.
+- Verifiziere, dass `docs/integration/API_CONTRACTS.yaml` keine Referenzen mehr enthält.

--- a/docs/playbooks/integrate-auth-system.md
+++ b/docs/playbooks/integrate-auth-system.md
@@ -1,0 +1,42 @@
+# Playbook: Integrate authentication system (future)
+
+## Goal
+Rollout eines zentralen Authentifizierungsdienstes für API, Dashboard und Worker-Komponenten.
+
+## Preparation
+- Entscheide über Auth-Provider (z. B. Auth0, Keycloak, Azure AD).
+- Definiere Rollenmodell (Viewer, Operator, Admin) und Zuordnung zu Agentenaktionen.
+- Plane Migrationspfad für bestehende Deployments ohne Downtime.
+
+## Target Architecture
+1. **Identity Provider** stellt OIDC/OAuth2 Tokens bereit.
+2. **FastAPI Backend** validiert Tokens via Middleware/Dependencies.
+3. **Frontend** nutzt PKCE Flow und persistiert Tokens sicher.
+4. **Worker** authentifizieren sich über Client Credentials für Management-Endpunkte.
+
+## Integration Steps (Draft)
+1. **Bootstrap Provider**
+   - Erstelle Tenants, Clients und Secrets.
+   - Konfiguriere Redirect-URIs (`http://localhost:5173/callback`, Produktionsdomains).
+2. **Backend Anpassung**
+   - Ergänze Auth-Dependency (z. B. `fastapi.security.OAuth2AuthorizationCodeBearer`).
+   - Sichere kritische Routen (`/tasks`, `/jobs/*`, `/api/env`, `/api/models`).
+   - Hinterlege Rollenprüfungen (z. B. Operator darf `/tasks`, Admin darf `/api/env`).
+3. **Frontend Update**
+   - Implementiere Login-Flow, Token-Speicher (Secure Storage) und Logout.
+   - Zeige Rollen im UI an und verstecke geschützte Aktionen.
+4. **Service Accounts**
+   - Für Celery Worker / Automationen Client-Credential-Flows bereitstellen.
+   - Secrets über `.env` und Settings-API verwalten.
+5. **Observability & Auditing**
+   - Aktivere Access Logs, Audit Events und Alarmierung bei Auth-Fehlern.
+   - Ergänze Telemetrie (`app/telemetry`) für Auth-Status.
+
+## Validation
+- End-to-End Tests mit verschiedenen Rollen.
+- Penetrationstest oder Security Review einplanen.
+- Update `docs/domains/authentication/README.md` mit finalem Design.
+
+## Rollback Plan
+- Feature-Flag einführen (`AUTH_ENABLED`).
+- Bei Problemen Flag deaktivieren, Tokens invalidieren und UIs informieren.

--- a/scripts/validate_openapi.py
+++ b/scripts/validate_openapi.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from fastapi import FastAPI
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.main import app as fastapi_app
+
+SPEC_PATH = Path("docs/integration/API_CONTRACTS.yaml")
+HTTP_METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
+
+
+def load_expected_spec() -> dict:
+    if not SPEC_PATH.exists():
+        raise FileNotFoundError(f"Spec file not found: {SPEC_PATH}")
+    return json.loads(SPEC_PATH.read_text())
+
+
+def normalize_paths(data: dict[str, dict]) -> dict[str, set[str]]:
+    normalized: dict[str, set[str]] = {}
+    for path, raw_ops in data.items():
+        if isinstance(raw_ops, dict) and raw_ops.get("x-kind") == "websocket":
+            # WebSocket-Routen sind nicht Teil des FastAPI OpenAPI-Schemas
+            continue
+        ops: set[str] = set()
+        for method in raw_ops.keys():
+            method_lower = method.lower()
+            if method_lower in HTTP_METHODS:
+                ops.add(method_lower)
+        if ops:
+            normalized[path] = ops
+    return normalized
+
+
+def validate_paths(app: FastAPI, expected: dict[str, dict]) -> list[str]:
+    openapi = app.openapi()
+    generated_paths = normalize_paths(openapi.get("paths", {}))
+    expected_paths = normalize_paths(expected.get("paths", {}))
+
+    errors: list[str] = []
+
+    missing_paths = sorted(set(expected_paths.keys()) - set(generated_paths.keys()))
+    extra_paths = sorted(set(generated_paths.keys()) - set(expected_paths.keys()))
+    if missing_paths:
+        errors.append(f"Missing paths in FastAPI schema: {missing_paths}")
+    if extra_paths:
+        errors.append(f"Paths exposed by FastAPI but not in spec: {extra_paths}")
+
+    for path, methods in expected_paths.items():
+        generated_methods = generated_paths.get(path, set())
+        missing_methods = sorted(methods - generated_methods)
+        if missing_methods:
+            errors.append(f"Missing methods for {path}: {missing_methods}")
+    return errors
+
+
+def validate_components(app: FastAPI, expected: dict[str, dict]) -> list[str]:
+    openapi = app.openapi()
+    generated_components = openapi.get("components", {}).get("schemas", {})
+    expected_components = expected.get("components", {}).get("schemas", {})
+
+    missing = sorted(set(expected_components.keys()) - set(generated_components.keys()))
+    if missing:
+        print(f"[WARN] Schemas missing in generated OpenAPI: {missing}")
+    return []
+
+
+def main() -> int:
+    expected_spec = load_expected_spec()
+    path_errors = validate_paths(fastapi_app, expected_spec)
+    component_errors = validate_components(fastapi_app, expected_spec)
+
+    errors = path_errors + component_errors
+    if errors:
+        for error in errors:
+            print(f"[ERROR] {error}")
+        return 1
+    print("OpenAPI contract matches generated schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_job_worker_logging.py
+++ b/tests/unit/test_job_worker_logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+if "dotenv" not in sys.modules:  # pragma: no cover - testing convenience
+    sys.modules["dotenv"] = SimpleNamespace(load_dotenv=lambda *args, **kwargs: None)
+
+from app.core.llm_logging import LLMTranscriptRecorder
+
+
+def test_recorder_simulates_job_worker_flow(tmp_path: Path) -> None:
+    recorder = LLMTranscriptRecorder()
+    recorder.record(
+        {
+            "job_id": "job-42",
+            "role": "cto-plan",
+            "model": "gpt-cto",
+            "provider": "openai",
+            "messages": [{"role": "system", "content": "Task"}],
+            "response_text": "[{\"title\": \"Step\"}]",
+            "response": [{"title": "Step"}],
+            "tokens_in": 12,
+            "tokens_out": 6,
+        }
+    )
+    recorder.set_base_path(tmp_path)
+    recorder.record(
+        {
+            "job_id": "job-42",
+            "step_id": "step-1",
+            "role": "coder-step",
+            "model": "gpt-coder",
+            "provider": "openai",
+            "messages": [{"role": "system", "content": "Code"}],
+            "response_text": "diff",
+            "summary": "summary",
+            "tokens_in": 30,
+            "tokens_out": 40,
+        }
+    )
+    log_path = tmp_path / ".autodev" / "llm_calls.jsonl"
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    plan_entry = json.loads(lines[0])
+    coder_entry = json.loads(lines[1])
+    assert plan_entry["response"][0]["title"] == "Step"
+    assert coder_entry["summary"] == "summary"
+    assert coder_entry["response_text"] == "diff"

--- a/tests/unit/test_llm_logging.py
+++ b/tests/unit/test_llm_logging.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+if "dotenv" not in sys.modules:  # pragma: no cover - testing convenience
+    sys.modules["dotenv"] = SimpleNamespace(load_dotenv=lambda *args, **kwargs: None)
+
+from app.core.llm_logging import LLMTranscriptRecorder, append_llm_log
+
+
+def test_append_llm_log_writes_json_line(tmp_path: Path) -> None:
+    entry = {
+        "job_id": "job-123",
+        "role": "cto-plan",
+        "model": "gpt-test",
+        "provider": "openai",
+        "messages": [{"role": "system", "content": "hello"}],
+        "response_text": "response",
+        "response": {"steps": []},
+        "tokens_in": 10,
+        "tokens_out": 5,
+    }
+    log_file = append_llm_log(tmp_path, entry)
+    contents = log_file.read_text(encoding="utf-8").strip().splitlines()
+    assert contents, "log file should contain at least one line"
+    payload = json.loads(contents[-1])
+    assert payload["response_text"] == "response"
+    assert payload["messages"][0]["content"] == "hello"
+    assert payload["tokens_in"] == 10
+    assert payload.get("timestamp"), "timestamp should be auto populated"
+
+
+def test_recorder_buffers_until_base_path(tmp_path: Path) -> None:
+    recorder = LLMTranscriptRecorder()
+    entry = {
+        "job_id": "job-123",
+        "role": "cto-plan",
+        "model": "gpt-test",
+        "provider": "openai",
+        "messages": [{"role": "system", "content": "hello"}],
+        "response_text": "response",
+        "response": {"steps": []},
+        "tokens_in": 10,
+        "tokens_out": 5,
+    }
+    recorder.record(entry)
+    log_path = tmp_path / ".autodev" / "llm_calls.jsonl"
+    assert not log_path.exists()
+    recorder.set_base_path(tmp_path)
+    assert log_path.exists()
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert payloads[0]["response_text"] == "response"
+
+
+def test_recorder_flushes_multiple_entries(tmp_path: Path) -> None:
+    recorder = LLMTranscriptRecorder()
+    recorder.record(
+        {
+            "job_id": "job-1",
+            "role": "cto-plan",
+            "model": "gpt-test",
+            "provider": "openai",
+            "messages": [{"role": "system", "content": "hello"}],
+            "response_text": "plan",
+            "response": {"steps": []},
+            "tokens_in": 2,
+            "tokens_out": 1,
+        }
+    )
+    recorder.set_base_path(tmp_path)
+    recorder.record(
+        {
+            "job_id": "job-1",
+            "role": "coder-step",
+            "step_id": "step-1",
+            "model": "gpt-test",
+            "provider": "openai",
+            "messages": [{"role": "system", "content": "code"}],
+            "response_text": "diff",
+            "summary": "summary",
+            "tokens_in": 3,
+            "tokens_out": 4,
+        }
+    )
+    log_path = tmp_path / ".autodev" / "llm_calls.jsonl"
+    payloads = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+    assert len(payloads) == 2
+    assert payloads[1]["role"] == "coder-step"
+    assert payloads[1]["response_text"] == "diff"


### PR DESCRIPTION
## Summary
- add a JSONL-based LLM transcript logger with buffering support until a repo path exists
- capture CTO planning and coder execution prompts/responses so jobs persist non-empty transcripts
- extend CTO plan API to expose raw text for logging and cover the new flow with unit tests

## Testing
- pytest tests/unit/test_llm_logging.py
- pytest tests/unit/test_job_worker_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e37ec11514832d8772319b49a015d8