### PR TITLE
Handle compact unified diff headers in diff parser

### DIFF
--- a/app/core/diffs.py
+++ b/app/core/diffs.py
@@ -9,7 +9,9 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
-HUNK_RE = re.compile(r"@@ -(?P<old_start>\d+)(?:,(?P<old_len>\d+))? \+(?P<new_start>\d+)(?:,(?P<new_len>\d+))? @@")
+HUNK_RE = re.compile(
+    r"@@\s*-(?P<old_start>\d+)(?:,(?P<old_len>\d+))?\s+\+(?P<new_start>\d+)(?:,(?P<new_len>\d+))?\s*@@.*"
+)
 
 
 def generate_unified_diff(original: str, updated: str, filename: str) -> str:
@@ -49,7 +51,7 @@ def apply_unified_diff(base_path: Path, diff_text: str) -> Iterable[Tuple[Path, 
             rebuilt: list[str] = []
             cursor = 0
             i += 1
-            while i < len(lines) and lines[i].startswith("@@ "):
+            while i < len(lines) and lines[i].startswith("@@"):
                 header = lines[i]
                 match = HUNK_RE.match(header)
                 if not match:
@@ -60,7 +62,7 @@ def apply_unified_diff(base_path: Path, diff_text: str) -> Iterable[Tuple[Path, 
                 rebuilt.extend(source_lines[cursor:old_start])
                 cursor = old_start
                 i += 1
-                while i < len(lines) and not lines[i].startswith("@@ ") and not lines[i].startswith("--- "):
+                while i < len(lines) and not lines[i].startswith("@@") and not lines[i].startswith("--- "):
                     hunk_line = lines[i]
                     if hunk_line.startswith(" "):
                         if cursor < len(source_lines):

--- a/tests/unit/test_diffs.py
+++ b/tests/unit/test_diffs.py
@@ -12,3 +12,30 @@ def test_apply_unified_diff(tmp_path):
     for path, content in apply_unified_diff(tmp_path, diff):
         safe_write(path, content)
     assert file_path.read_text(encoding="utf-8") == updated
+
+
+def test_apply_unified_diff_without_space_after_hunk_prefix(tmp_path):
+    diff = """--- /dev/null
++++ b/new_file.txt
+@@-0,0 +1 @@
++content line
+"""
+    results = list(apply_unified_diff(tmp_path, diff))
+    assert results == [(tmp_path / "new_file.txt", "content line\n")]
+
+
+def test_apply_unified_diff_with_context_header_suffix(tmp_path):
+    original = "def greet():\n    return 'hi'\n"
+    updated = "def greet():\n    return 'hello'\n"
+    file_path = tmp_path / "module.py"
+    file_path.write_text(original, encoding="utf-8")
+    diff = """--- a/module.py
++++ b/module.py
+@@ -1,2 +1,2 @@ def greet():
+ def greet():
+-    return 'hi'
++    return 'hello'
+"""
+    for path, content in apply_unified_diff(tmp_path, diff):
+        safe_write(path, content)
+    assert file_path.read_text(encoding="utf-8") == updated


### PR DESCRIPTION
## Summary
- relax the unified diff hunk header parsing to support compact headers and trailing context text
- add regression tests covering missing-space and context-suffixed hunk headers to keep new behavior stable

## Testing
- `uv run python - <<'PY'
from pathlib import Path
from app.core.diffs import apply_unified_diff

diff = """--- /dev/null
+++ b/new_file.txt
@@-0,0 +1 @@
+content line
"""
print(list(apply_unified_diff(Path('.'), diff)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68e3856144f4832db04486fe70f00a2c