### PR TITLE
feat: enhance branch selection in task form

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -157,6 +157,16 @@ export class ApiClient {
       .then((response) => this.getJob(response.job_id));
   }
 
+  listBranches(owner: string, repo: string) {
+    const params = new URLSearchParams({
+      owner,
+      repo,
+    });
+    return this.request<{ branches: string[] }>(
+      `/api/github/branches?${params.toString()}`,
+    );
+  }
+
   getJob(jobId: string) {
     return this.request<Job>(`/jobs/${encodeURIComponent(jobId)}`);
   }


### PR DESCRIPTION
## Summary
- fetch available branches from the API when repository details change in the job creator form
- swap the base branch input for a dropdown populated with fetched branches and default to master when available
- add API client helper for branch listing and keep existing styling while providing graceful fallback to manual input

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ad2014f0832d90183224ad236370