### PR TITLE
Implement AUTH Platform Registration & Email Verification (Turnstile CAPTCHA, Celery Email, Verification Tokens)

### DIFF
--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Authentication service package."""

--- a/backend/auth/api/__init__.py
+++ b/backend/auth/api/__init__.py
@@ -1,0 +1,5 @@
+"""API exports for the auth backend."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/auth/api/routes.py
+++ b/backend/auth/api/routes.py
@@ -1,0 +1,88 @@
+"""FastAPI routes for registration and email verification flows."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from backend.auth.schemas.registration import (
+    RegistrationRequest,
+    RegistrationResponse,
+    ResendVerificationRequest,
+    ResendVerificationResponse,
+)
+from backend.auth.service.registration_service import (
+    complete_email_verification,
+    register_user,
+    resend_verification,
+)
+from backend.core.config import AppConfig, get_settings
+from backend.db.session import get_db
+from backend.redis.client import get_redis_client
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/v1/auth", tags=["auth"])
+
+
+def _client_ip(request: Request) -> str | None:
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return None
+
+
+@router.post("/register", response_model=RegistrationResponse)
+async def register_endpoint(
+    payload: RegistrationRequest,
+    request: Request,
+    session: Session = Depends(get_db),
+    settings: AppConfig = Depends(get_settings),
+):
+    """Register a new user and send the verification email."""
+
+    redis = get_redis_client()
+    message = await register_user(
+        session=session,
+        request=payload,
+        settings=settings,
+        remote_ip=_client_ip(request),
+        redis=redis,
+    )
+    logger.info("api.register.completed", email=payload.email)
+    return RegistrationResponse(message=message)
+
+
+@router.post("/resend-verification", response_model=ResendVerificationResponse)
+async def resend_verification_endpoint(
+    payload: ResendVerificationRequest,
+    session: Session = Depends(get_db),
+    settings: AppConfig = Depends(get_settings),
+):
+    """Resend verification email for an unverified user."""
+
+    redis = get_redis_client()
+    message = await resend_verification(session=session, request=payload, settings=settings, redis=redis)
+    logger.info("api.resend.completed", email=payload.email)
+    return ResendVerificationResponse(message=message)
+
+
+@router.get("/verify-email")
+async def verify_email_endpoint(
+    token: str,
+    session: Session = Depends(get_db),
+    settings: AppConfig = Depends(get_settings),
+):
+    """Verify the email using the provided token and redirect to the login page."""
+
+    await complete_email_verification(session=session, token=token, settings=settings)
+    redirect_url = f"{settings.frontend_base_url}/login?verified=1"
+    logger.info("api.verify.redirect", redirect_url=redirect_url)
+    return RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
+
+
+__all__ = ["router"]

--- a/backend/auth/email/__init__.py
+++ b/backend/auth/email/__init__.py
@@ -1,0 +1,5 @@
+"""Email utilities for the auth service."""
+
+from .tasks import enqueue_verification_email, send_verification_email_task
+
+__all__ = ["enqueue_verification_email", "send_verification_email_task"]

--- a/backend/auth/email/celery_app.py
+++ b/backend/auth/email/celery_app.py
@@ -1,0 +1,26 @@
+"""Celery application setup for auth email tasks."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from celery import Celery
+
+from backend.core.config import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_celery_app() -> Celery:
+    settings = get_settings()
+    celery_app = Celery(
+        "backend.auth",
+        broker=settings.celery_broker_url,
+        backend=settings.celery_result_backend,
+    )
+    celery_app.conf.task_default_queue = "auth-emails"
+    celery_app.conf.task_default_exchange = "auth-emails"
+    celery_app.conf.task_default_routing_key = "auth-emails"
+    return celery_app
+
+
+__all__ = ["get_celery_app"]

--- a/backend/auth/email/tasks.py
+++ b/backend/auth/email/tasks.py
@@ -1,0 +1,39 @@
+"""Celery tasks for authentication-related emails."""
+
+from __future__ import annotations
+
+import structlog
+
+from backend.auth.email.celery_app import get_celery_app
+from backend.auth.email.templates import render_verification_email
+
+logger = structlog.get_logger(__name__)
+
+celery_app = get_celery_app()
+
+
+@celery_app.task(name="backend.auth.email.send_verification_email", bind=True)
+def send_verification_email_task(self, *, to_email: str, verification_url: str) -> None:
+    """Send the verification email to the provided address.
+
+    In production this task would integrate with the transactional email provider.
+    For now we log the rendered content so the worker remains side-effect free
+    in tests.
+    """
+
+    content = render_verification_email(verification_url)
+    logger.info(
+        "email.verification.dispatched",
+        to_email=to_email,
+        subject=content.subject,
+        verification_url=verification_url,
+    )
+
+
+def enqueue_verification_email(to_email: str, verification_url: str) -> None:
+    """Enqueue the verification email to be sent asynchronously."""
+
+    send_verification_email_task.delay(to_email=to_email, verification_url=verification_url)
+
+
+__all__ = ["enqueue_verification_email", "send_verification_email_task"]

--- a/backend/auth/email/templates.py
+++ b/backend/auth/email/templates.py
@@ -1,0 +1,36 @@
+"""Email templates for authentication flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class EmailContent:
+    """Represents rendered email content."""
+
+    subject: str
+    text_body: str
+    html_body: str
+
+
+def render_verification_email(verification_url: str) -> EmailContent:
+    """Create the email content for confirming a user's email address."""
+
+    subject = "Bitte bestätige deine E-Mail"
+    text_body = (
+        "Willkommen bei Feature Auth!\n\n"
+        "Bitte bestätige deine E-Mail-Adresse, indem du den folgenden Link öffnest:\n"
+        f"{verification_url}\n\n"
+        "Dieser Link ist 24 Stunden gültig. Danach verfällt die Registrierung automatisch.\n"
+    )
+    html_body = (
+        "<p>Willkommen bei Feature Auth!</p>"
+        "<p>Bitte bestätige deine E-Mail-Adresse, indem du auf den folgenden Link klickst:</p>"
+        f'<p><a href="{verification_url}">{verification_url}</a></p>'
+        "<p>Dieser Link ist 24 Stunden gültig. Danach verfällt die Registrierung automatisch.</p>"
+    )
+    return EmailContent(subject=subject, text_body=text_body, html_body=html_body)
+
+
+__all__ = ["EmailContent", "render_verification_email"]

--- a/backend/auth/schemas/__init__.py
+++ b/backend/auth/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Schema exports for the auth service."""
+
+from .registration import (
+    RegistrationRequest,
+    RegistrationResponse,
+    ResendVerificationRequest,
+    ResendVerificationResponse,
+)
+
+__all__ = [
+    "RegistrationRequest",
+    "RegistrationResponse",
+    "ResendVerificationRequest",
+    "ResendVerificationResponse",
+]

--- a/backend/auth/schemas/registration.py
+++ b/backend/auth/schemas/registration.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for registration and verification flows."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, SecretStr
+
+
+class RegistrationRequest(BaseModel):
+    """Input payload for new account registration."""
+
+    email: EmailStr
+    password: SecretStr = Field(..., min_length=12)
+    captcha_token: str = Field(..., alias="captchaToken", min_length=1)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class RegistrationResponse(BaseModel):
+    """Response payload acknowledging registration submission."""
+
+    message: str
+
+
+class ResendVerificationRequest(BaseModel):
+    """Input payload for resending verification email."""
+
+    email: EmailStr
+
+
+class ResendVerificationResponse(BaseModel):
+    """Response payload for resend endpoint."""
+
+    message: str
+
+
+__all__ = [
+    "RegistrationRequest",
+    "RegistrationResponse",
+    "ResendVerificationRequest",
+    "ResendVerificationResponse",
+]

--- a/backend/auth/service/__init__.py
+++ b/backend/auth/service/__init__.py
@@ -1,0 +1,15 @@
+"""Service layer exports for auth flows."""
+
+from .registration_service import (
+    complete_email_verification,
+    register_user,
+    resend_verification,
+    validate_email_verification_token,
+)
+
+__all__ = [
+    "register_user",
+    "resend_verification",
+    "complete_email_verification",
+    "validate_email_verification_token",
+]

--- a/backend/auth/service/captcha.py
+++ b/backend/auth/service/captcha.py
@@ -1,0 +1,59 @@
+"""Cloudflare Turnstile CAPTCHA verification service."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+import structlog
+from fastapi import HTTPException, status
+
+from backend.core.config import AppConfig
+
+logger = structlog.get_logger(__name__)
+
+
+@asynccontextmanager
+async def _get_client(provided: httpx.AsyncClient | None) -> AsyncIterator[httpx.AsyncClient]:
+    if provided is not None:
+        yield provided
+        return
+    async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
+        yield client
+
+
+async def verify_turnstile(
+    *,
+    captcha_token: str,
+    settings: AppConfig,
+    remote_ip: str | None = None,
+    http_client: httpx.AsyncClient | None = None,
+) -> None:
+    """Validate the CAPTCHA token with Cloudflare Turnstile."""
+
+    if not captcha_token:
+        logger.info("captcha.turnstile.missing")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Captcha-Verifizierung fehlgeschlagen.")
+
+    data = {"secret": settings.turnstile_secret_key, "response": captcha_token}
+    if remote_ip:
+        data["remoteip"] = remote_ip
+
+    async with _get_client(http_client) as client:
+        try:
+            response = await client.post(settings.turnstile_verify_url, data=data)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network failure path
+            logger.error("captcha.turnstile.http_error", error=str(exc))
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Captcha-Verifizierung fehlgeschlagen.") from exc
+
+    payload = response.json()
+    if not payload.get("success", False):
+        logger.info("captcha.turnstile.failed", errors=payload.get("error-codes", []))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Captcha-Verifizierung fehlgeschlagen.")
+
+    logger.info("captcha.turnstile.verified", action="register", remote_ip=remote_ip)
+
+
+__all__ = ["verify_turnstile"]

--- a/backend/auth/service/rate_limit.py
+++ b/backend/auth/service/rate_limit.py
@@ -1,0 +1,57 @@
+"""Rate limit helpers for authentication flows."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import HTTPException, status
+from redis.asyncio import Redis
+
+from backend.core.config import AppConfig
+
+logger = structlog.get_logger(__name__)
+
+
+async def enforce_rate_limit(
+    redis: Redis,
+    *,
+    settings: AppConfig,
+    scope: str,
+    identifier: str,
+    limit: int,
+    window_seconds: int,
+) -> None:
+    """Increment the rate limit counter and raise if the limit is exceeded."""
+
+    if not identifier:
+        return
+
+    key = f"{settings.redis_rate_limit_prefix}:{scope}:{identifier}"
+    current = await redis.incr(key)
+    if current == 1:
+        await redis.expire(key, window_seconds)
+
+    if current > limit:
+        ttl = await redis.ttl(key)
+        logger.info(
+            "rate_limit.exceeded",
+            scope=scope,
+            identifier=identifier,
+            limit=limit,
+            ttl=ttl,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded. Please try again later.",
+        )
+
+    logger.info(
+        "rate_limit.hit",
+        scope=scope,
+        identifier=identifier,
+        current=current,
+        limit=limit,
+        window_seconds=window_seconds,
+    )
+
+
+__all__ = ["enforce_rate_limit"]

--- a/backend/auth/service/registration_service.py
+++ b/backend/auth/service/registration_service.py
@@ -1,0 +1,305 @@
+"""Registration and verification token lifecycle management."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import structlog
+from fastapi import HTTPException, status
+from redis.asyncio import Redis
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from backend.auth.email.tasks import enqueue_verification_email
+from backend.auth.schemas.registration import RegistrationRequest, ResendVerificationRequest
+from backend.auth.service.captcha import verify_turnstile
+from backend.auth.service.rate_limit import enforce_rate_limit
+from backend.core.config import AppConfig
+from backend.db.models.user import EmailVerification, User, UserStatus
+from backend.redis.client import get_redis_client
+from backend.security.passwords import get_password_service
+
+logger = structlog.get_logger(__name__)
+
+VERIFICATION_WINDOW_HOURS = 24
+
+
+def _sign_verification_token(verification_id: uuid.UUID, *, secret: str) -> str:
+    signature = hmac.new(secret.encode("utf-8"), str(verification_id).encode("utf-8"), hashlib.sha256)
+    return signature.hexdigest()
+
+
+def _hash_token(signature: str) -> str:
+    return hashlib.sha256(signature.encode("utf-8")).hexdigest()
+
+
+def _build_verification_token(record: EmailVerification, *, secret: str) -> str:
+    signature = _sign_verification_token(record.id, secret=secret)
+    return f"{record.id}.{signature}"
+
+
+def _verification_url(token: str, *, settings: AppConfig) -> str:
+    return f"{settings.api_base_url}/v1/auth/verify-email?token={token}"
+
+
+def _store_token_hash(record: EmailVerification, *, secret: str) -> None:
+    signature = _sign_verification_token(record.id, secret=secret)
+    record.token_hash = _hash_token(signature)
+
+
+def _create_email_verification(session: Session, user: User, settings: AppConfig) -> tuple[EmailVerification, str]:
+    verification = EmailVerification(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=VERIFICATION_WINDOW_HOURS),
+    )
+    _store_token_hash(verification, secret=settings.email_verification_secret)
+    session.add(verification)
+    session.flush()
+    token = _build_verification_token(verification, secret=settings.email_verification_secret)
+    return verification, token
+
+
+def _existing_active_token(session: Session, user: User, *, now: datetime) -> EmailVerification | None:
+    stmt = (
+        select(EmailVerification)
+        .where(
+            EmailVerification.user_id == user.id,
+            EmailVerification.used_at.is_(None),
+            EmailVerification.expires_at > now,
+        )
+        .order_by(EmailVerification.created_at.desc())
+        .limit(1)
+    )
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def _purge_tokens(session: Session, user: User) -> None:
+    stmt = delete(EmailVerification).where(EmailVerification.user_id == user.id)
+    session.execute(stmt)
+
+
+def _ensure_timezone(dt: datetime) -> datetime:
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+async def register_user(
+    *,
+    session: Session,
+    request: RegistrationRequest,
+    settings: AppConfig,
+    remote_ip: str | None,
+    http_client=None,
+    redis: Redis | None = None,
+) -> str:
+    """Handle registration flow and enqueue verification email."""
+
+    await verify_turnstile(
+        captcha_token=request.captcha_token,
+        settings=settings,
+        remote_ip=remote_ip,
+        http_client=http_client,
+    )
+
+    redis_client = redis or get_redis_client()
+    await enforce_rate_limit(
+        redis_client,
+        settings=settings,
+        scope="register",
+        identifier=remote_ip or "",
+        limit=5,
+        window_seconds=3600,
+    )
+
+    email = request.email.lower()
+    password_service = get_password_service()
+    raw_password = request.password.get_secret_value()
+    hashed_password = password_service.hash(raw_password)
+
+    stmt = select(User).where(User.email == email)
+    user = session.execute(stmt).scalar_one_or_none()
+    now = datetime.now(timezone.utc)
+
+    if user and user.status == UserStatus.ACTIVE and user.email_verified_at is not None:
+        logger.info("registration.email_already_verified", email=email)
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
+
+    message = "Registrierung fast abgeschlossen — bitte bestätige deine E-Mail. Der Link ist 24 Stunden gültig."
+
+    if user:
+        logger.info("registration.unverified_retry", user_id=str(user.id), email=email)
+        active_token = _existing_active_token(session, user, now=now)
+        if active_token is None:
+            _purge_tokens(session, user)
+            user.password_hash = hashed_password
+            verification, token = _create_email_verification(session, user, settings)
+            verification_url = _verification_url(token, settings=settings)
+            enqueue_verification_email(user.email, verification_url)
+            logger.info(
+                "registration.verification_reissued",
+                user_id=str(user.id),
+                email=email,
+                verification_id=str(verification.id),
+            )
+            return message
+
+        token = _build_verification_token(active_token, secret=settings.email_verification_secret)
+        verification_url = _verification_url(token, settings=settings)
+        enqueue_verification_email(user.email, verification_url)
+        logger.info(
+            "registration.verification_resent",
+            user_id=str(user.id),
+            email=email,
+            verification_id=str(active_token.id),
+        )
+        return message
+
+    user = User(
+        email=email,
+        status=UserStatus.UNVERIFIED,
+        password_hash=hashed_password,
+    )
+    session.add(user)
+    session.flush()
+
+    verification, token = _create_email_verification(session, user, settings)
+    verification_url = _verification_url(token, settings=settings)
+    enqueue_verification_email(user.email, verification_url)
+
+    logger.info(
+        "registration.created",
+        user_id=str(user.id),
+        email=email,
+        verification_id=str(verification.id),
+    )
+    return message
+
+
+async def resend_verification(
+    *,
+    session: Session,
+    request: ResendVerificationRequest,
+    settings: AppConfig,
+    redis: Redis | None = None,
+) -> str:
+    """Handle resend verification flow with rate limiting."""
+
+    email = request.email.lower()
+
+    stmt = select(User).where(User.email == email)
+    user = session.execute(stmt).scalar_one_or_none()
+    if not user or user.status != UserStatus.UNVERIFIED:
+        logger.info("registration.resend.no_unverified_user", email=email)
+        return "Wenn ein Konto mit dieser E-Mail existiert, haben wir den Link erneut gesendet."
+
+    redis_client = redis or get_redis_client()
+    await enforce_rate_limit(
+        redis_client,
+        settings=settings,
+        scope="resend_verification",
+        identifier=str(user.id),
+        limit=3,
+        window_seconds=86400,
+    )
+
+    now = datetime.now(timezone.utc)
+    active_token = _existing_active_token(session, user, now=now)
+    if active_token is None:
+        _purge_tokens(session, user)
+        verification, token = _create_email_verification(session, user, settings)
+        logger.info(
+            "registration.resend.new_token",
+            user_id=str(user.id),
+            email=email,
+            verification_id=str(verification.id),
+        )
+    else:
+        verification = active_token
+        token = _build_verification_token(active_token, secret=settings.email_verification_secret)
+        logger.info(
+            "registration.resend.existing_token",
+            user_id=str(user.id),
+            email=email,
+            verification_id=str(verification.id),
+        )
+
+    verification_url = _verification_url(token, settings=settings)
+    enqueue_verification_email(user.email, verification_url)
+    return "Registrierung fast abgeschlossen — bitte bestätige deine E-Mail. Der Link ist 24 Stunden gültig."
+
+
+def validate_email_verification_token(session: Session, token: str, settings: AppConfig) -> EmailVerification:
+    """Validate token integrity and lookup the verification record."""
+
+    try:
+        verification_id_str, signature = token.split(".")
+        verification_id = uuid.UUID(verification_id_str)
+    except (ValueError, AttributeError):
+        logger.info("verification.invalid_format")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    stmt = select(EmailVerification).where(EmailVerification.id == verification_id)
+    verification = session.execute(stmt).scalar_one_or_none()
+    if verification is None:
+        logger.info("verification.not_found", verification_id=verification_id_str)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    expected_hash = _hash_token(signature)
+    if verification.token_hash != expected_hash:
+        logger.info("verification.signature_mismatch", verification_id=verification_id_str)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    return verification
+
+
+async def complete_email_verification(
+    *,
+    session: Session,
+    token: str,
+    settings: AppConfig,
+) -> tuple[User, EmailVerification, bool]:
+    """Mark verification as complete if token valid; return whether expired."""
+
+    verification = validate_email_verification_token(session, token, settings)
+
+    if verification.used_at is not None:
+        logger.info("verification.already_used", verification_id=str(verification.id))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    expires_at = _ensure_timezone(verification.expires_at)
+    if expires_at <= datetime.now(timezone.utc):
+        user = session.get(User, verification.user_id)
+        if user:
+            logger.info("verification.expired", user_id=str(user.id), verification_id=str(verification.id))
+            _purge_tokens(session, user)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    user = session.get(User, verification.user_id)
+    if not user:
+        logger.info("verification.user_missing", verification_id=str(verification.id))
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ungültiger oder abgelaufener Bestätigungslink.")
+
+    user.status = UserStatus.ACTIVE
+    user.email_verified_at = datetime.now(timezone.utc)
+    verification.used_at = datetime.now(timezone.utc)
+    _purge_tokens(session, user)
+
+    logger.info(
+        "verification.completed",
+        user_id=str(user.id),
+        verification_id=str(verification.id),
+    )
+    return user, verification, True
+
+
+__all__ = [
+    "register_user",
+    "resend_verification",
+    "complete_email_verification",
+    "validate_email_verification_token",
+]

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -40,6 +40,21 @@ class AppConfig(BaseSettings):
     argon2_parallelism: int = Field(default=4, validation_alias="ARGON2_PARALLELISM")
     argon2_hash_len: int = Field(default=32, validation_alias="ARGON2_HASH_LEN")
 
+    turnstile_secret_key: str = Field(validation_alias="TURNSTILE_SECRET_KEY")
+    turnstile_verify_url: str = Field(
+        default="https://challenges.cloudflare.com/turnstile/v0/siteverify",
+        validation_alias="TURNSTILE_VERIFY_URL",
+    )
+
+    celery_broker_url: str = Field(validation_alias="CELERY_BROKER_URL")
+    celery_result_backend: str | None = Field(default=None, validation_alias="CELERY_RESULT_BACKEND")
+
+    email_from_address: str = Field(validation_alias="EMAIL_FROM_ADDRESS")
+    email_from_name: str = Field(default="Feature Auth", validation_alias="EMAIL_FROM_NAME")
+    frontend_base_url: str = Field(validation_alias="FRONTEND_BASE_URL")
+    api_base_url: str = Field(validation_alias="API_BASE_URL")
+    email_verification_secret: str = Field(validation_alias="EMAIL_VERIFICATION_SECRET")
+
     log_level: str = Field(default="INFO", validation_alias="LOG_LEVEL")
     log_redact_fields: List[str] = Field(default_factory=lambda: ["password", "token", "secret"], validation_alias="LOG_REDACT_FIELDS")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pydantic-settings>=2.4",
     "python-dotenv>=1.0",
     "python-multipart>=0.0.9",
+    "email-validator>=2.2",
     "redis>=5.0.4",
     "requests>=2.32",
     "sqlalchemy>=2.0.34",

--- a/tests/backend/auth/test_registration.py
+++ b/tests/backend/auth/test_registration.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from importlib import reload
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from fakeredis import aioredis
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from backend.auth.schemas.registration import (
+    RegistrationRequest,
+    ResendVerificationRequest,
+)
+from backend.auth.service.captcha import verify_turnstile
+from backend.db.base import Base
+from backend.db.models.user import EmailVerification, User, UserStatus
+from backend.security.passwords import get_password_service
+
+
+@pytest.fixture
+def db_session(settings_env) -> Session:
+    """Provide an isolated in-memory SQLite session for each test."""
+
+    from sqlalchemy import create_engine
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, future=True)
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine, expire_on_commit=False, future=True)
+    session = TestingSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest_asyncio.fixture
+async def fake_redis() -> aioredis.FakeRedis:
+    client = aioredis.FakeRedis()
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest.fixture
+def registration_service(settings_env):
+    import backend.auth.email.tasks as email_tasks
+    import backend.auth.service.registration_service as service
+
+    reload(email_tasks)
+    reload(service)
+    return service
+
+
+@pytest.fixture
+def email_outbox(monkeypatch, registration_service):
+    sent: list[dict[str, Any]] = []
+
+    def _capture(email: str, url: str) -> None:
+        sent.append({"email": email, "url": url})
+
+    monkeypatch.setattr(registration_service, "enqueue_verification_email", _capture)
+    return sent
+
+
+@pytest.fixture(autouse=True)
+def stub_captcha(monkeypatch, registration_service):
+    async def _noop(**kwargs):
+        return None
+
+    monkeypatch.setattr(registration_service, "verify_turnstile", _noop)
+
+
+@pytest.mark.asyncio
+async def test_turnstile_success(settings_env):
+    class DummyResponse:
+        def __init__(self, data: dict[str, Any]):
+            self._data = data
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return self._data
+
+    class DummyClient:
+        async def post(self, url: str, data: dict[str, Any]):
+            assert data["secret"] == settings_env.turnstile_secret_key
+            return DummyResponse({"success": True})
+
+    await verify_turnstile(captcha_token="token", settings=settings_env, http_client=DummyClient())
+
+
+@pytest.mark.asyncio
+async def test_turnstile_failure(settings_env):
+    class DummyResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"success": False, "error-codes": ["invalid-input-response"]}
+
+    class DummyClient:
+        async def post(self, url: str, data: dict[str, Any]):
+            return DummyResponse()
+
+    with pytest.raises(HTTPException) as exc:
+        await verify_turnstile(captcha_token="bad", settings=settings_env, http_client=DummyClient())
+    assert exc.value.status_code == 400
+    assert "Captcha" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_register_new_user(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="alice@example.com", password="SuperSecret!23", captchaToken="token")
+
+    message = await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="203.0.113.10",
+        redis=fake_redis,
+    )
+
+    assert "Registrierung fast abgeschlossen" in message
+    assert len(email_outbox) == 1
+
+    user = db_session.execute(select(User)).scalar_one()
+    assert user.status == UserStatus.UNVERIFIED
+    assert user.email == "alice@example.com"
+    assert get_password_service().verify(user.password_hash, "SuperSecret!23")
+
+    verification = db_session.execute(select(EmailVerification)).scalar_one()
+    token = email_outbox[0]["url"].split("token=")[1]
+    assert token.split(".")[0] == str(verification.id)
+
+
+@pytest.mark.asyncio
+async def test_register_existing_verified_conflict(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    password_hash = get_password_service().hash("ExistingSecret!45")
+    user = User(
+        email="bob@example.com",
+        status=UserStatus.ACTIVE,
+        email_verified_at=datetime.now(timezone.utc),
+        password_hash=password_hash,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    request = RegistrationRequest(email="bob@example.com", password="AnotherSecret!56", captchaToken="token")
+
+    with pytest.raises(HTTPException) as exc:
+        await registration_service.register_user(
+            session=db_session,
+            request=request,
+            settings=settings_env,
+            remote_ip="198.51.100.7",
+            redis=fake_redis,
+        )
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Email already registered"
+    assert len(email_outbox) == 0
+
+
+@pytest.mark.asyncio
+async def test_register_resends_existing_token(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="carol@example.com", password="Password!234", captchaToken="token")
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="203.0.113.11",
+        redis=fake_redis,
+    )
+
+    first_token = email_outbox[0]["url"].split("token=")[1]
+
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="203.0.113.11",
+        redis=fake_redis,
+    )
+
+    assert len(email_outbox) == 2
+    second_token = email_outbox[1]["url"].split("token=")[1]
+    assert first_token == second_token
+
+    count = db_session.execute(select(EmailVerification)).scalars().all()
+    assert len(count) == 1
+
+
+@pytest.mark.asyncio
+async def test_register_with_expired_token_creates_new(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="dave@example.com", password="Password!234", captchaToken="token")
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="192.0.2.1",
+        redis=fake_redis,
+    )
+
+    verification = db_session.execute(select(EmailVerification)).scalar_one()
+    verification.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.flush()
+
+    await registration_service.register_user(
+        session=db_session,
+        request=RegistrationRequest(email="dave@example.com", password="NewSecret!345", captchaToken="token"),
+        settings=settings_env,
+        remote_ip="192.0.2.1",
+        redis=fake_redis,
+    )
+
+    assert len(email_outbox) == 2
+    first_token = email_outbox[0]["url"].split("token=")[1]
+    second_token = email_outbox[1]["url"].split("token=")[1]
+    assert first_token != second_token
+
+    verifications = db_session.execute(select(EmailVerification)).scalars().all()
+    assert len(verifications) == 1
+    user = db_session.execute(select(User)).scalar_one()
+    assert get_password_service().verify(user.password_hash, "NewSecret!345")
+
+
+@pytest.mark.asyncio
+async def test_resend_rate_limit(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="erin@example.com", password="Password!234", captchaToken="token")
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="192.0.2.3",
+        redis=fake_redis,
+    )
+
+    resend_request = ResendVerificationRequest(email="erin@example.com")
+    for _ in range(3):
+        await registration_service.resend_verification(
+            session=db_session,
+            request=resend_request,
+            settings=settings_env,
+            redis=fake_redis,
+        )
+
+    with pytest.raises(HTTPException) as exc:
+        await registration_service.resend_verification(
+            session=db_session,
+            request=resend_request,
+            settings=settings_env,
+            redis=fake_redis,
+        )
+    assert exc.value.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_complete_email_verification_success(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="frank@example.com", password="Password!234", captchaToken="token")
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="192.0.2.4",
+        redis=fake_redis,
+    )
+
+    url = email_outbox[-1]["url"]
+    token = url.split("token=")[1]
+
+    user, verification, _ = await registration_service.complete_email_verification(
+        session=db_session,
+        token=token,
+        settings=settings_env,
+    )
+
+    assert user.status == UserStatus.ACTIVE
+    assert user.email_verified_at is not None
+    assert verification.used_at is not None
+    assert db_session.execute(select(EmailVerification)).scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_complete_email_verification_expired(db_session: Session, settings_env, fake_redis, email_outbox, registration_service):
+    request = RegistrationRequest(email="gina@example.com", password="Password!234", captchaToken="token")
+    await registration_service.register_user(
+        session=db_session,
+        request=request,
+        settings=settings_env,
+        remote_ip="192.0.2.5",
+        redis=fake_redis,
+    )
+
+    verification = db_session.execute(select(EmailVerification)).scalar_one()
+    verification.expires_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    db_session.flush()
+    token = email_outbox[-1]["url"].split("token=")[1]
+
+    with pytest.raises(HTTPException) as exc:
+        await registration_service.complete_email_verification(
+            session=db_session,
+            token=token,
+            settings=settings_env,
+        )
+    assert exc.value.status_code == 400
+
+    user = db_session.execute(select(User)).scalar_one()
+    assert user.status == UserStatus.UNVERIFIED
+    assert user.email_verified_at is None
+    assert db_session.execute(select(EmailVerification)).scalars().all() == []

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -3,8 +3,26 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal environments
+    serialization = None  # type: ignore[assignment]
+    ec = None  # type: ignore[assignment]
+
+
+STATIC_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYzvF5QGOObz7qJmd
+5Aq71+v+P6lZ2dWr4RVjuBTBBPGhRANCAASkDRF24Iyxn8ddchArm8KTW9nW1wdO
+6Xd7wOpEtVCNrECD8/TvQypVeeLh5aHTmurroCuVNz3nEncB3Gm/y4pe4A4
+-----END PRIVATE KEY-----
+"""
+
+STATIC_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpA0RduCMsZ/HXXIQK5vCk1vZ1tcHTul3
+e8DqRLVQjaxAg/P070MqVXni4eWh05rq6ArlTc95xJ3Adxpv8uKXuA==
+-----END PUBLIC KEY-----
+"""
 
 from backend.core import config
 
@@ -17,16 +35,21 @@ def settings_env(monkeypatch, tmp_path: Path):
     public_dir.mkdir()
 
     for kid in ("current", "rotated"):
-        private_key = ec.generate_private_key(ec.SECP256R1())
-        private_pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        )
-        public_pem = private_key.public_key().public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
+        if serialization and ec:
+            private_key = ec.generate_private_key(ec.SECP256R1())
+            private_pem = private_key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+            public_pem = private_key.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+        else:
+            private_pem = STATIC_PRIVATE_KEY.encode("utf-8")
+            public_pem = STATIC_PUBLIC_KEY.encode("utf-8")
+
         (private_dir / f"{kid}.pem").write_bytes(private_pem)
         (public_dir / f"{kid}.pem").write_bytes(public_pem)
 
@@ -43,6 +66,14 @@ def settings_env(monkeypatch, tmp_path: Path):
         "ARGON2_TIME_COST": "2",
         "ARGON2_MEMORY_COST": "32768",
         "ARGON2_PARALLELISM": "2",
+        "TURNSTILE_SECRET_KEY": "test-turnstile-secret",
+        "CELERY_BROKER_URL": "memory://",
+        "CELERY_RESULT_BACKEND": "rpc://",
+        "EMAIL_FROM_ADDRESS": "no-reply@example.com",
+        "EMAIL_FROM_NAME": "Feature Auth",
+        "FRONTEND_BASE_URL": "https://app.example.com",
+        "API_BASE_URL": "https://api.example.com",
+        "EMAIL_VERIFICATION_SECRET": "verification-secret",
     }
 
     for key, value in env_vars.items():

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.16.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/ca/4dc52902cf3491892d464f5265a81e9dff094692c8a049a3ed6a05fe7ee8/alembic-1.16.5.tar.gz", hash = "sha256:a88bb7f6e513bd4301ecf4c7f2206fe93f9913f9b48dac3b78babde2d6fe765e", size = 1969868, upload-time = "2025-08-27T18:02:05.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/4a/4c61d4c84cfd9befb6fa08a702535b27b21fff08c946bc2f6139decbf7f7/alembic-1.16.5-py3-none-any.whl", hash = "sha256:e845dfe090c5ffa7b92593ae6687c5cb1a101e91fa53868497dbd79847f9dbe3", size = 247355, upload-time = "2025-08-27T18:02:07.37Z" },
+]
+
+[[package]]
 name = "amqp"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -48,6 +62,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -95,15 +142,21 @@ name = "auto-dev-orchestrator-py"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "anyio" },
+    { name = "argon2-cffi" },
     { name = "celery" },
+    { name = "cryptography" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "gitpython" },
     { name = "gradio" },
     { name = "httpx" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pygithub" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "redis" },
@@ -115,21 +168,29 @@ dependencies = [
 
 [package.optional-dependencies]
 tests = [
+    { name = "fakeredis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.13" },
     { name = "anyio", specifier = ">=4.4" },
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "celery", specifier = ">=5.4" },
+    { name = "cryptography", specifier = ">=42.0" },
+    { name = "email-validator", specifier = ">=2.2" },
+    { name = "fakeredis", marker = "extra == 'tests'", specifier = ">=2.23" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "gitpython", specifier = ">=3.1.44" },
     { name = "gradio", specifier = ">=4.44" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pydantic-settings", specifier = ">=2.4" },
     { name = "pygithub", specifier = ">=2.3" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=8.3" },
     { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -380,6 +441,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/15/52/ea7e2b1910f547baed566c866fbb86de2402e501a89ecb4871ea7f169a81/cryptography-46.0.2-cp38-abi3-win32.whl", hash = "sha256:0b507c8e033307e37af61cb9f7159b416173bdf5b41d11c4df2e499a1d8e007c", size = 3036711, upload-time = "2025-10-01T00:28:47.096Z" },
     { url = "https://files.pythonhosted.org/packages/71/9e/171f40f9c70a873e73c2efcdbe91e1d4b1777a03398fa1c4af3c56a2477a/cryptography-46.0.2-cp38-abi3-win_amd64.whl", hash = "sha256:f9b2dc7668418fb6f221e4bf701f716e05e8eadb4f1988a2487b11aedf8abe62", size = 3500007, upload-time = "2025-10-01T00:28:48.967Z" },
     { url = "https://files.pythonhosted.org/packages/3e/7c/15ad426257615f9be8caf7f97990cf3dcbb5b8dd7ed7e0db581a1c4759dd/cryptography-46.0.2-cp38-abi3-win_arm64.whl", hash = "sha256:91447f2b17e83c9e0c89f133119d83f94ce6e0fb55dd47da0a959316e6e9cfa1", size = 2918153, upload-time = "2025-10-01T00:28:51.003Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/1e/27170815a9768d2eaf72e66dfad38047b55ea278df84b539ad0045ca1538/fakeredis-2.31.3.tar.gz", hash = "sha256:76dfb92855f0787a4936a5b4fdb1905c5909ec790e62dff2b8896b412905deb0", size = 170984, upload-time = "2025-09-22T12:24:54.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d6/7cad31e16b7d8343ed7abf5ddb039a063b32a300def1aa487d91b4a5c831/fakeredis-2.31.3-py3-none-any.whl", hash = "sha256:12aa54a3fb00984c18b28956addb91683aaf55b2dc2ef4b09d49bd481032e57a", size = 118398, upload-time = "2025-09-22T12:24:52.751Z" },
 ]
 
 [[package]]
@@ -678,6 +774,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -924,6 +1032,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f1/0258a123c045afaf3c3b60c22ccff077bceeb24b8dc2c593270899353bd0/psycopg-3.2.10.tar.gz", hash = "sha256:0bce99269d16ed18401683a8569b2c5abd94f72f8364856d56c0389bcd50972a", size = 160380, upload-time = "2025-09-08T09:13:37.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/90/422ffbbeeb9418c795dae2a768db860401446af0c6768bc061ce22325f58/psycopg-3.2.10-py3-none-any.whl", hash = "sha256:ab5caf09a9ec42e314a21f5216dbcceac528e0e05142e42eea83a3b28b320ac3", size = 206586, upload-time = "2025-09-08T09:07:50.121Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.2.10"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/34/91c127fdedf8b270b1e3acc9f849d07ee8b80194379590c6f48dcc842924/psycopg_binary-3.2.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1dee2f4d2adc9adacbfecf8254bd82f6ac95cff707e1b9b99aa721cd1ef16b47", size = 3983963, upload-time = "2025-09-08T09:09:38.454Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/03/1d10ce2bf70cf549a8019639dc0c49be03e41092901d4324371a968b8c01/psycopg_binary-3.2.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8b45e65383da9c4a42a56f817973e521e893f4faae897fe9f1a971f9fe799742", size = 4069171, upload-time = "2025-09-08T09:09:44.395Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5e/39cb924d6e119145aa5fc5532f48e79c67e13a76675e9366c327098db7b5/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:484d2b1659afe0f8f1cef5ea960bb640e96fa864faf917086f9f833f5c7a8034", size = 4610780, upload-time = "2025-09-08T09:09:53.073Z" },
+    { url = "https://files.pythonhosted.org/packages/20/05/5a1282ebc4e39f5890abdd4bb7edfe9d19e4667497a1793ad288a8b81826/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3bb4046973264ebc8cb7e20a83882d68577c1f26a6f8ad4fe52e4468cd9a8eee", size = 4700479, upload-time = "2025-09-08T09:09:58.183Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7a/e1c06e558ca3f37b7e6b002e555ebcfce0bf4dee6f3ae589a7444e16ce17/psycopg_binary-3.2.10-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:14bcbcac0cab465d88b2581e43ec01af4b01c9833e663f1352e05cb41be19e44", size = 4391772, upload-time = "2025-09-08T09:10:04.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d6/56f449c86988c9a97dc6c5f31d3689cfe8aedb37f2a02bd3e3882465d385/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70bb7f665587dfd79e69f48b34efe226149454d7aab138ed22d5431d703de2f6", size = 3858214, upload-time = "2025-09-08T09:10:09.693Z" },
+    { url = "https://files.pythonhosted.org/packages/93/56/f9eed67c9a1701b1e315f3687ff85f2f22a0a7d0eae4505cff65ef2f2679/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d2fe9eaa367f6171ab1a21a7dcb335eb2398be7f8bb7e04a20e2260aedc6f782", size = 3528051, upload-time = "2025-09-08T09:10:13.423Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/636709c72540cb859566537c0a03e46c3d2c4c4c2e13f78df46b6c4082b3/psycopg_binary-3.2.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:299834cce3eec0c48aae5a5207fc8f0c558fd65f2ceab1a36693329847da956b", size = 3580117, upload-time = "2025-09-08T09:10:17.81Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/a8/a2c822fa06b0dbbb8ad4b0221da2534f77bac54332d2971dbf930f64be5a/psycopg_binary-3.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:e037aac8dc894d147ef33056fc826ee5072977107a3fdf06122224353a057598", size = 2878872, upload-time = "2025-09-08T09:10:22.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/80/db840f7ebf948ab05b4793ad34d4da6ad251829d6c02714445ae8b5f1403/psycopg_binary-3.2.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:55b14f2402be027fe1568bc6c4d75ac34628ff5442a70f74137dadf99f738e3b", size = 3982057, upload-time = "2025-09-08T09:10:28.725Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/53/39308328bb8388b1ec3501a16128c5ada405f217c6d91b3d921b9f3c5604/psycopg_binary-3.2.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:43d803fb4e108a67c78ba58f3e6855437ca25d56504cae7ebbfbd8fce9b59247", size = 4066830, upload-time = "2025-09-08T09:10:34.083Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/5a/18e6f41b40c71197479468cb18703b2999c6e4ab06f9c05df3bf416a55d7/psycopg_binary-3.2.10-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:470594d303928ab72a1ffd179c9c7bde9d00f76711d6b0c28f8a46ddf56d9807", size = 4610747, upload-time = "2025-09-08T09:10:39.697Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ab/9198fed279aca238c245553ec16504179d21aad049958a2865d0aa797db4/psycopg_binary-3.2.10-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a1d4e4d309049e3cb61269652a3ca56cb598da30ecd7eb8cea561e0d18bc1a43", size = 4700301, upload-time = "2025-09-08T09:10:44.715Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/0d/59024313b5e6c5da3e2a016103494c609d73a95157a86317e0f600c8acb3/psycopg_binary-3.2.10-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a92ff1c2cd79b3966d6a87e26ceb222ecd5581b5ae4b58961f126af806a861ed", size = 4392679, upload-time = "2025-09-08T09:10:49.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/47/21ef15d8a66e3a7a76a177f885173d27f0c5cbe39f5dd6eda9832d6b4e19/psycopg_binary-3.2.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac0365398947879c9827b319217096be727da16c94422e0eb3cf98c930643162", size = 3857881, upload-time = "2025-09-08T09:10:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/af/35/c5e5402ccd40016f15d708bbf343b8cf107a58f8ae34d14dc178fdea4fd4/psycopg_binary-3.2.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:42ee399c2613b470a87084ed79b06d9d277f19b0457c10e03a4aef7059097abc", size = 3531135, upload-time = "2025-09-08T09:11:03.346Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e2/9b82946859001fe5e546c8749991b8b3b283f40d51bdc897d7a8e13e0a5e/psycopg_binary-3.2.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2028073fc12cd70ba003309d1439c0c4afab4a7eee7653b8c91213064fffe12b", size = 3581813, upload-time = "2025-09-08T09:11:08.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/91/c10cfccb75464adb4781486e0014ecd7c2ad6decf6cbe0afd8db65ac2bc9/psycopg_binary-3.2.10-cp313-cp313-win_amd64.whl", hash = "sha256:8390db6d2010ffcaf7f2b42339a2da620a7125d37029c1f9b72dfb04a8e7be6f", size = 2881466, upload-time = "2025-09-08T09:11:14.078Z" },
 ]
 
 [[package]]
@@ -1293,6 +1444,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add FastAPI registration, resend, and email verification routes leveraging Turnstile CAPTCHA and Redis rate limiting
- implement verification token lifecycle, Celery email enqueueing, and supporting configuration updates
- cover registration and verification flows with unit tests for CAPTCHA validation, resend logic, and token expiry handling

## Testing
- .venv/bin/python -m pytest tests/backend/auth/test_registration.py

------
https://chatgpt.com/codex/tasks/task_e_68e3dcc86420832db53808a633849fd7