### PR TITLE
Implement Plans & Limits (plan management, spend caps, enforcement hook, FE billing/limits)

### DIFF
--- a/alembic/versions/202501101200_add_spend_records_and_limits.py
+++ b/alembic/versions/202501101200_add_spend_records_and_limits.py
@@ -1,0 +1,87 @@
+"""Add spend records table and widen spend limit precision."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "202501101200"
+down_revision = "202410091200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "spend_limits",
+        "monthly_cap_usd",
+        existing_type=sa.Numeric(10, 2),
+        type_=sa.Numeric(12, 2),
+        existing_nullable=False,
+    )
+
+    op.create_table(
+        "spend_records",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("timezone('utc', now())"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("timezone('utc', now())"), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("amount_usd", sa.Numeric(12, 2), nullable=False),
+        sa.Column("metadata", sa.JSON()),
+    )
+    op.create_index("ix_spend_records_user_month", "spend_records", ["user_id", "created_at"])
+
+    plans_table = sa.table(
+        "plans",
+        sa.column("id", postgresql.UUID(as_uuid=True)),
+        sa.column("code", sa.String()),
+        sa.column("name", sa.String()),
+        sa.column("monthly_price_usd", sa.Numeric(10, 2)),
+        sa.column("metadata", sa.JSON()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+    conn = op.get_bind()
+    existing_codes = {row[0] for row in conn.execute(sa.select(plans_table.c.code))}
+    now = datetime.now(timezone.utc)
+    seed_data = []
+    if "FREE" not in existing_codes:
+        seed_data.append({
+            "id": uuid.uuid4(),
+            "code": "FREE",
+            "name": "Free",
+            "monthly_price_usd": 0,
+            "metadata": {"features": ["Basic usage", "Community support"]},
+            "created_at": now,
+            "updated_at": now,
+        })
+    if "PRO" not in existing_codes:
+        seed_data.append({
+            "id": uuid.uuid4(),
+            "code": "PRO",
+            "name": "Pro",
+            "monthly_price_usd": 99,
+            "metadata": {"features": ["Priority queue", "Usage analytics", "Premium support"]},
+            "created_at": now,
+            "updated_at": now,
+        })
+
+    for row in seed_data:
+        conn.execute(plans_table.insert().values(**row))
+
+
+def downgrade() -> None:
+    op.drop_index("ix_spend_records_user_month", table_name="spend_records")
+    op.drop_table("spend_records")
+    op.alter_column(
+        "spend_limits",
+        "monthly_cap_usd",
+        existing_type=sa.Numeric(12, 2),
+        type_=sa.Numeric(10, 2),
+        existing_nullable=False,
+    )

--- a/app/services/billing.py
+++ b/app/services/billing.py
@@ -1,0 +1,17 @@
+"""Integration helpers for spend cap enforcement from the orchestrator."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+from backend.account.enforcement import CAP_BLOCK_MESSAGE, EnforcementResult, enforce_spend_cap as _enforce_spend_cap
+
+
+def enforce_spend_cap(user_id: UUID, estimated_usd: Decimal | float | int) -> EnforcementResult:
+    """Proxy to the account service spend cap enforcement."""
+
+    return _enforce_spend_cap(user_id=user_id, estimated_usd=estimated_usd)
+
+
+__all__ = ["enforce_spend_cap", "EnforcementResult", "CAP_BLOCK_MESSAGE"]

--- a/backend/account/__init__.py
+++ b/backend/account/__init__.py
@@ -1,0 +1,5 @@
+"""Account management package for plans and spend limits."""
+
+from . import schemas
+
+__all__ = ["schemas"]

--- a/backend/account/api/__init__.py
+++ b/backend/account/api/__init__.py
@@ -1,0 +1,5 @@
+"""Account API exports."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/backend/account/api/routes.py
+++ b/backend/account/api/routes.py
@@ -1,0 +1,167 @@
+"""FastAPI routes for account plan management and spend limits."""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, Request, Response
+from redis.asyncio import Redis
+from sqlalchemy.orm import Session
+
+from backend.account import schemas
+from backend.account.dependencies import get_redis
+from backend.account.schemas import PlanResponse, PlanUpdateRequest, SpendLimitResponse, SpendLimitUpdateRequest
+from backend.account.services import (
+    LIMITS_CHANGED_EVENT,
+    PLAN_CHANGED_EVENT,
+    WARNING_HEADER_VALUE,
+    PlanService,
+    SpendAccountingService,
+    SpendLimitService,
+)
+from backend.auth.api.deps import require_current_user
+from backend.auth.service.rate_limit import enforce_rate_limit
+from backend.core.config import AppConfig, get_settings
+from backend.db.models.user import User
+from backend.db.session import get_db
+
+router = APIRouter(prefix="/v1/account", tags=["account"])
+logger = structlog.get_logger(__name__)
+
+PLAN_RATE_LIMIT = 5
+LIMIT_RATE_LIMIT = 10
+WINDOW_SECONDS = 3600
+
+
+def _client_ip(request: Request) -> str | None:
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return None
+
+
+def _user_agent(request: Request) -> str | None:
+    return request.headers.get("user-agent")
+
+
+@router.get("/plan", response_model=PlanResponse)
+async def get_plan(
+    request: Request,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
+) -> PlanResponse:
+    plan_service = PlanService(session)
+    plan = plan_service.get_active_plan(current_user.id)
+    session.commit()
+    return PlanResponse(plan=schemas.PlanCode(plan.code), name=plan.name, monthly_price_usd=plan.monthly_price_usd)
+
+
+@router.post("/plan", response_model=PlanResponse)
+async def update_plan(
+    payload: PlanUpdateRequest,
+    request: Request,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
+    settings: AppConfig = Depends(get_settings),
+    redis: Redis = Depends(get_redis),
+) -> PlanResponse:
+    await enforce_rate_limit(
+        redis,
+        settings=settings,
+        scope="account:plan",
+        identifier=str(current_user.id),
+        limit=PLAN_RATE_LIMIT,
+        window_seconds=WINDOW_SECONDS,
+    )
+
+    plan_service = PlanService(session)
+    plan = plan_service.set_plan(
+        user_id=current_user.id,
+        plan_code=payload.plan,
+        actor_user_id=current_user.id,
+        ip=_client_ip(request),
+        user_agent=_user_agent(request),
+    )
+    session.commit()
+    logger.info(PLAN_CHANGED_EVENT, user_id=str(current_user.id), plan=plan.code)
+    return PlanResponse(plan=schemas.PlanCode(plan.code), name=plan.name, monthly_price_usd=plan.monthly_price_usd)
+
+
+@router.get("/limits", response_model=SpendLimitResponse)
+async def get_limits(
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
+) -> SpendLimitResponse:
+    limit_service = SpendLimitService(session)
+    limit = limit_service.get_or_create(current_user.id)
+    accounting = SpendAccountingService(session)
+    totals = accounting.get_month_totals(current_user.id)
+    session.commit()
+
+    if totals.cap_reached and not totals.hard_stop:
+        response.headers["X-Spend-Warning"] = WARNING_HEADER_VALUE
+
+    return SpendLimitResponse(
+        monthly_cap_usd=limit.monthly_cap_usd,
+        hard_stop=limit.hard_stop,
+        usage_usd=totals.usage_usd,
+        remaining_usd=totals.remaining_usd,
+        cap_reached=totals.cap_reached,
+    )
+
+
+@router.post("/limits", response_model=SpendLimitResponse)
+async def update_limits(
+    payload: SpendLimitUpdateRequest,
+    request: Request,
+    response: Response,
+    session: Session = Depends(get_db),
+    current_user: User = Depends(require_current_user),
+    settings: AppConfig = Depends(get_settings),
+    redis: Redis = Depends(get_redis),
+) -> SpendLimitResponse:
+    await enforce_rate_limit(
+        redis,
+        settings=settings,
+        scope="account:limits",
+        identifier=str(current_user.id),
+        limit=LIMIT_RATE_LIMIT,
+        window_seconds=WINDOW_SECONDS,
+    )
+
+    limit_service = SpendLimitService(session)
+    limit = limit_service.update_limits(
+        user_id=current_user.id,
+        monthly_cap_usd=payload.monthly_cap_usd,
+        hard_stop=payload.hard_stop,
+        actor_user_id=current_user.id,
+        ip=_client_ip(request),
+        user_agent=_user_agent(request),
+    )
+    accounting = SpendAccountingService(session)
+    totals = accounting.get_month_totals(current_user.id)
+    session.commit()
+
+    if totals.cap_reached and not totals.hard_stop:
+        response.headers["X-Spend-Warning"] = WARNING_HEADER_VALUE
+
+    logger.info(
+        LIMITS_CHANGED_EVENT,
+        user_id=str(current_user.id),
+        monthly_cap_usd=str(limit.monthly_cap_usd),
+        hard_stop=limit.hard_stop,
+    )
+
+    return SpendLimitResponse(
+        monthly_cap_usd=limit.monthly_cap_usd,
+        hard_stop=limit.hard_stop,
+        usage_usd=totals.usage_usd,
+        remaining_usd=totals.remaining_usd,
+        cap_reached=totals.cap_reached,
+    )
+
+
+__all__ = ["router", "CAP_BLOCK_MESSAGE"]

--- a/backend/account/dependencies.py
+++ b/backend/account/dependencies.py
@@ -1,0 +1,34 @@
+"""FastAPI dependency helpers for account APIs."""
+
+from __future__ import annotations
+
+from fastapi import Depends
+from redis.asyncio import Redis
+
+from backend.auth.api.deps import require_current_user
+from backend.core.config import get_settings
+from backend.db.session import get_db
+from backend.redis.client import get_redis_client
+
+
+def CurrentUser() -> Depends:  # type: ignore[override]
+    return Depends(require_current_user)
+
+
+def DbSession() -> Depends:  # type: ignore[override]
+    return Depends(get_db)
+
+
+def AppSettings() -> Depends:  # type: ignore[override]
+    return Depends(get_settings)
+
+
+async def get_redis() -> Redis:
+    return get_redis_client()
+
+
+def RedisClient() -> Depends:  # type: ignore[override]
+    return Depends(get_redis)
+
+
+__all__ = ["CurrentUser", "DbSession", "AppSettings", "RedisClient", "require_current_user", "get_redis"]

--- a/backend/account/enforcement.py
+++ b/backend/account/enforcement.py
@@ -1,0 +1,93 @@
+"""Spend cap enforcement helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from fastapi import HTTPException, status
+
+from backend.account.services import SpendAccountingService, SpendCapState, WARNING_HEADER_VALUE
+from backend.db.session import session_scope
+
+CAP_BLOCK_MESSAGE = "Your monthly spending limit has been reached. Adjust your limit to continue."
+
+
+@dataclass(slots=True)
+class EnforcementResult:
+    """Result returned from spend cap enforcement."""
+
+    cap_reached: bool
+    hard_stop: bool
+    remaining_usd: Decimal
+    warning_header: str | None = None
+
+
+def _run_enforcement(
+    service: SpendAccountingService,
+    *,
+    user_id: UUID,
+    estimated_usd: Decimal | float | int,
+    actor_user_id: UUID | None,
+    ip: str | None,
+    user_agent: str | None,
+    raise_on_block: bool,
+) -> EnforcementResult:
+    state: SpendCapState = service.enforce_cap(
+        user_id=user_id,
+        estimated_usd=estimated_usd,
+        actor_user_id=actor_user_id,
+        ip=ip,
+        user_agent=user_agent,
+    )
+    if state.cap_reached and state.hard_stop and raise_on_block:
+        raise HTTPException(status_code=status.HTTP_402_PAYMENT_REQUIRED, detail=CAP_BLOCK_MESSAGE)
+
+    warning = WARNING_HEADER_VALUE if state.cap_reached and not state.hard_stop else None
+    return EnforcementResult(
+        cap_reached=state.cap_reached,
+        hard_stop=state.hard_stop,
+        remaining_usd=state.remaining_usd,
+        warning_header=warning,
+    )
+
+
+def enforce_spend_cap(
+    user_id: UUID,
+    estimated_usd: Decimal | float | int,
+    *,
+    actor_user_id: UUID | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+    session=None,
+    raise_on_block: bool = True,
+) -> EnforcementResult:
+    """Check whether the estimated spend exceeds the configured cap."""
+
+    if session is not None:
+        service = SpendAccountingService(session)
+        return _run_enforcement(
+            service,
+            user_id=user_id,
+            estimated_usd=estimated_usd,
+            actor_user_id=actor_user_id,
+            ip=ip,
+            user_agent=user_agent,
+            raise_on_block=raise_on_block,
+        )
+
+    with session_scope() as scoped_session:
+        service = SpendAccountingService(scoped_session)
+        return _run_enforcement(
+            service,
+            user_id=user_id,
+            estimated_usd=estimated_usd,
+            actor_user_id=actor_user_id,
+            ip=ip,
+            user_agent=user_agent,
+            raise_on_block=raise_on_block,
+        )
+
+
+__all__ = ["enforce_spend_cap", "EnforcementResult", "CAP_BLOCK_MESSAGE"]

--- a/backend/account/schemas.py
+++ b/backend/account/schemas.py
@@ -1,0 +1,66 @@
+"""Pydantic schemas for account plan and spend limit APIs."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PlanCode(str, Enum):
+    """Supported subscription plans."""
+
+    FREE = "FREE"
+    PRO = "PRO"
+
+
+class PlanResponse(BaseModel):
+    """Response payload describing the active plan for a user."""
+
+    plan: PlanCode
+    name: str
+    monthly_price_usd: Decimal = Field(..., ge=Decimal("0"))
+
+
+class PlanUpdateRequest(BaseModel):
+    """Request payload to update the active plan."""
+
+    plan: PlanCode
+
+
+class SpendLimitResponse(BaseModel):
+    """Response payload describing the current spend limit state."""
+
+    monthly_cap_usd: Decimal = Field(..., ge=Decimal("0"))
+    hard_stop: bool
+    usage_usd: Decimal = Field(..., ge=Decimal("0"))
+    remaining_usd: Decimal = Field(..., ge=Decimal("0"))
+    cap_reached: bool
+
+
+class SpendLimitUpdateRequest(BaseModel):
+    """Request payload to update spend limits."""
+
+    monthly_cap_usd: Decimal = Field(..., ge=Decimal("0"))
+    hard_stop: bool
+
+
+class SpendTotals(BaseModel):
+    """Aggregate spend totals for the current UTC month."""
+
+    usage_usd: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+    cap_usd: Decimal | None = Field(default=None, ge=Decimal("0"))
+    remaining_usd: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+    cap_reached: bool = False
+    hard_stop: bool = False
+
+
+__all__ = [
+    "PlanCode",
+    "PlanResponse",
+    "PlanUpdateRequest",
+    "SpendLimitResponse",
+    "SpendLimitUpdateRequest",
+    "SpendTotals",
+]

--- a/backend/account/services.py
+++ b/backend/account/services.py
@@ -1,0 +1,332 @@
+"""Service layer for account plan management and spend accounting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Iterable
+from uuid import UUID
+
+import structlog
+from sqlalchemy import Select, and_, func, select
+from sqlalchemy.orm import Session
+
+from backend.account.schemas import PlanCode, SpendTotals
+from backend.db.models.audit import AuditLog
+from backend.db.models.billing import (
+    Plan,
+    PlanStatus,
+    SpendLimit,
+    SpendRecord,
+    UserPlan,
+)
+
+logger = structlog.get_logger(__name__)
+
+AUDIT_TARGET = "user"
+WARNING_HEADER_VALUE = "cap_reached"
+CAP_REACHED_EVENT = "cap_reached"
+PLAN_CHANGED_EVENT = "plan_changed"
+LIMITS_CHANGED_EVENT = "limits_changed"
+SPEND_RECORDED_EVENT = "spend_recorded"
+
+
+@dataclass(slots=True)
+class SpendCapState:
+    """State returned by spend cap enforcement routines."""
+
+    cap_reached: bool
+    hard_stop: bool
+    remaining_usd: Decimal
+
+
+def _quantize(amount: Decimal | float | int) -> Decimal:
+    dec = Decimal(str(amount))
+    return dec.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _month_bounds(moment: datetime | None = None) -> tuple[datetime, datetime]:
+    now = moment or datetime.now(UTC)
+    start = datetime(now.year, now.month, 1, tzinfo=UTC)
+    if now.month == 12:
+        end = datetime(now.year + 1, 1, 1, tzinfo=UTC)
+    else:
+        end = datetime(now.year, now.month + 1, 1, tzinfo=UTC)
+    return start, end
+
+
+def _record_audit(
+    session: Session,
+    *,
+    actor_user_id: UUID | None,
+    target_user_id: UUID,
+    action: str,
+    metadata: dict[str, Any] | None = None,
+    ip: str | None = None,
+    user_agent: str | None = None,
+) -> None:
+    entry = AuditLog(
+        actor_user_id=actor_user_id,
+        action=action,
+        target_type=AUDIT_TARGET,
+        target_id=str(target_user_id),
+        metadata_json=metadata,
+        ip=ip,
+        user_agent=user_agent,
+        occurred_at=datetime.now(UTC),
+    )
+    session.add(entry)
+
+
+class PlanService:
+    """Manage plan assignments for users."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def get_active_plan(self, user_id: UUID) -> Plan:
+        plan_join: Select[tuple[Plan]] = (
+            select(Plan)
+            .join(UserPlan, UserPlan.plan_id == Plan.id)
+            .where(UserPlan.user_id == user_id, UserPlan.status == PlanStatus.ACTIVE)
+            .order_by(UserPlan.created_at.desc())
+        )
+        plan = self._session.scalars(plan_join).first()
+        if plan:
+            return plan
+
+        # Auto-enroll in FREE plan if none exists
+        free_plan = self.get_plan_by_code(PlanCode.FREE)
+        enrollment = UserPlan(user_id=user_id, plan_id=free_plan.id, status=PlanStatus.ACTIVE)
+        self._session.add(enrollment)
+        logger.info("plan.auto_assigned", user_id=str(user_id), plan=free_plan.code)
+        return free_plan
+
+    def get_plan_by_code(self, code: PlanCode) -> Plan:
+        plan = self._session.scalar(select(Plan).where(Plan.code == code.value))
+        if not plan:
+            raise ValueError(f"Plan {code.value} is not configured")
+        return plan
+
+    def set_plan(
+        self,
+        *,
+        user_id: UUID,
+        plan_code: PlanCode,
+        actor_user_id: UUID | None,
+        ip: str | None,
+        user_agent: str | None,
+    ) -> Plan:
+        plan = self.get_plan_by_code(plan_code)
+        active = self._session.scalar(
+            select(UserPlan).where(UserPlan.user_id == user_id, UserPlan.status == PlanStatus.ACTIVE)
+        )
+        if active and active.plan_id == plan.id:
+            logger.info(PLAN_CHANGED_EVENT, user_id=str(user_id), plan=plan.code, changed=False)
+            return plan
+
+        if active:
+            active.status = PlanStatus.CANCELED
+            active.cancelled_at = datetime.now(UTC)
+
+        enrollment = UserPlan(user_id=user_id, plan_id=plan.id, status=PlanStatus.ACTIVE)
+        self._session.add(enrollment)
+        logger.info(PLAN_CHANGED_EVENT, user_id=str(user_id), plan=plan.code, changed=True)
+        _record_audit(
+            self._session,
+            actor_user_id=actor_user_id,
+            target_user_id=user_id,
+            action=PLAN_CHANGED_EVENT,
+            metadata={"plan": plan.code},
+            ip=ip,
+            user_agent=user_agent,
+        )
+        return plan
+
+    def admin_override_plan(
+        self,
+        *,
+        actor_user_id: UUID,
+        target_user_id: UUID,
+        plan_code: PlanCode,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> Plan:
+        return self.set_plan(
+            user_id=target_user_id,
+            plan_code=plan_code,
+            actor_user_id=actor_user_id,
+            ip=ip,
+            user_agent=user_agent,
+        )
+
+
+class SpendLimitService:
+    """Manage spend limits for users."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def get_or_create(self, user_id: UUID) -> SpendLimit:
+        limit = self._session.scalar(select(SpendLimit).where(SpendLimit.user_id == user_id))
+        if limit:
+            return limit
+        limit = SpendLimit(user_id=user_id, monthly_cap_usd=Decimal("0.00"), hard_stop=False)
+        self._session.add(limit)
+        self._session.flush()
+        return limit
+
+    def update_limits(
+        self,
+        *,
+        user_id: UUID,
+        monthly_cap_usd: Decimal,
+        hard_stop: bool,
+        actor_user_id: UUID | None,
+        ip: str | None,
+        user_agent: str | None,
+    ) -> SpendLimit:
+        monthly_cap_usd = _quantize(monthly_cap_usd)
+        limit = self.get_or_create(user_id)
+        limit.monthly_cap_usd = monthly_cap_usd
+        limit.hard_stop = hard_stop
+        logger.info(
+            LIMITS_CHANGED_EVENT,
+            user_id=str(user_id),
+            monthly_cap_usd=str(monthly_cap_usd),
+            hard_stop=hard_stop,
+        )
+        _record_audit(
+            self._session,
+            actor_user_id=actor_user_id,
+            target_user_id=user_id,
+            action=LIMITS_CHANGED_EVENT,
+            metadata={"monthly_cap_usd": str(monthly_cap_usd), "hard_stop": hard_stop},
+            ip=ip,
+            user_agent=user_agent,
+        )
+        return limit
+
+    def admin_override_limits(
+        self,
+        *,
+        actor_user_id: UUID,
+        target_user_id: UUID,
+        monthly_cap_usd: Decimal,
+        hard_stop: bool,
+        ip: str | None = None,
+        user_agent: str | None = None,
+    ) -> SpendLimit:
+        return self.update_limits(
+            user_id=target_user_id,
+            monthly_cap_usd=monthly_cap_usd,
+            hard_stop=hard_stop,
+            actor_user_id=actor_user_id,
+            ip=ip,
+            user_agent=user_agent,
+        )
+
+
+class SpendAccountingService:
+    """Record spend and compute usage totals."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    def record(self, user_id: UUID, usd_amount: Decimal | float | int, meta: dict[str, Any] | None = None) -> SpendRecord:
+        amount = _quantize(usd_amount)
+        record = SpendRecord(user_id=user_id, amount_usd=amount, metadata_json=meta or {})
+        self._session.add(record)
+        logger.info(SPEND_RECORDED_EVENT, user_id=str(user_id), amount=str(amount))
+        _record_audit(
+            self._session,
+            actor_user_id=user_id,
+            target_user_id=user_id,
+            action=SPEND_RECORDED_EVENT,
+            metadata={"amount_usd": str(amount), "meta": meta or {}},
+        )
+        return record
+
+    def get_month_totals(self, user_id: UUID) -> SpendTotals:
+        start, end = _month_bounds()
+        total = self._session.scalar(
+            select(func.coalesce(func.sum(SpendRecord.amount_usd), Decimal("0.00")))
+            .where(
+                and_(
+                    SpendRecord.user_id == user_id,
+                    SpendRecord.created_at >= start,
+                    SpendRecord.created_at < end,
+                )
+            )
+        )
+        total = _quantize(total or Decimal("0.00"))
+
+        limit = self._session.scalar(select(SpendLimit).where(SpendLimit.user_id == user_id))
+        cap = _quantize(limit.monthly_cap_usd) if limit else Decimal("0.00")
+        hard_stop = bool(limit.hard_stop) if limit else False
+        remaining = cap - total
+        if remaining < Decimal("0.00"):
+            remaining = Decimal("0.00")
+        cap_reached = cap > Decimal("0.00") and total >= cap
+        return SpendTotals(
+            usage_usd=total,
+            cap_usd=cap,
+            remaining_usd=remaining,
+            cap_reached=cap_reached,
+            hard_stop=hard_stop,
+        )
+
+    def enforce_cap(
+        self,
+        *,
+        user_id: UUID,
+        estimated_usd: Decimal | float | int,
+        actor_user_id: UUID | None,
+        ip: str | None,
+        user_agent: str | None,
+    ) -> SpendCapState:
+        totals = self.get_month_totals(user_id)
+        projected_usage = totals.usage_usd + _quantize(estimated_usd)
+        cap = totals.cap_usd or Decimal("0.00")
+        cap_reached = cap > Decimal("0.00") and projected_usage >= cap
+        if cap_reached:
+            logger.info(
+                CAP_REACHED_EVENT,
+                user_id=str(user_id),
+                cap=str(cap),
+                usage=str(totals.usage_usd),
+                estimated=str(estimated_usd),
+                hard_stop=totals.hard_stop,
+            )
+            _record_audit(
+                self._session,
+                actor_user_id=actor_user_id,
+                target_user_id=user_id,
+                action=CAP_REACHED_EVENT,
+                metadata={
+                    "cap_usd": str(cap),
+                    "usage_usd": str(totals.usage_usd),
+                    "estimated_usd": str(_quantize(estimated_usd)),
+                    "hard_stop": totals.hard_stop,
+                },
+                ip=ip,
+                user_agent=user_agent,
+            )
+        remaining = cap - projected_usage
+        if remaining < Decimal("0.00"):
+            remaining = Decimal("0.00")
+        return SpendCapState(cap_reached=cap_reached, hard_stop=totals.hard_stop, remaining_usd=remaining)
+
+
+__all__ = [
+    "PlanService",
+    "SpendAccountingService",
+    "SpendLimitService",
+    "SpendCapState",
+    "WARNING_HEADER_VALUE",
+    "CAP_REACHED_EVENT",
+    "PLAN_CHANGED_EVENT",
+    "LIMITS_CHANGED_EVENT",
+    "SPEND_RECORDED_EVENT",
+]

--- a/backend/auth/api/deps.py
+++ b/backend/auth/api/deps.py
@@ -1,0 +1,47 @@
+"""Shared dependencies for auth-protected routes."""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.orm import Session
+
+from backend.db.models.user import User, UserStatus
+from backend.db.session import get_db
+from backend.security.jwt_service import get_jwt_service
+
+logger = structlog.get_logger(__name__)
+_http_bearer = HTTPBearer(auto_error=False)
+
+
+async def require_current_user(request: Request, session: Session = Depends(get_db)) -> User:
+    credentials: HTTPAuthorizationCredentials | None = await _http_bearer(request)
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You don’t have permission to perform this action.")
+
+    token = credentials.credentials
+    jwt_service = get_jwt_service()
+    try:
+        payload = jwt_service.decode(token)
+    except Exception as exc:  # pragma: no cover - invalid token paths
+        logger.info("api.auth.invalid_token", error=str(exc))
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You don’t have permission to perform this action.") from exc
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You don’t have permission to perform this action.")
+
+    try:
+        user_id = uuid.UUID(str(payload.get("sub")))
+    except Exception as exc:  # pragma: no cover - malformed sub
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You don’t have permission to perform this action.") from exc
+
+    user = session.get(User, user_id)
+    if not user or user.status != UserStatus.ACTIVE:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You don’t have permission to perform this action.")
+    return user
+
+
+__all__ = ["require_current_user", "_http_bearer"]

--- a/backend/db/models/__init__.py
+++ b/backend/db/models/__init__.py
@@ -1,7 +1,7 @@
 """ORM model exports for the authentication platform."""
 
 from backend.db.models.audit import AuditLog
-from backend.db.models.billing import Plan, PlanStatus, SpendLimit, UserPlan
+from backend.db.models.billing import Plan, PlanStatus, SpendLimit, SpendRecord, UserPlan
 from backend.db.models.user import (
     EmailVerification,
     PasswordReset,
@@ -17,6 +17,7 @@ __all__ = [
     "Plan",
     "PlanStatus",
     "SpendLimit",
+    "SpendRecord",
     "UserPlan",
     "EmailVerification",
     "PasswordReset",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,9 @@
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@tailwindcss/forms": "^0.5.10",
+        "@testing-library/jest-dom": "^6.4.5",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/node": "^24.6.2",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -29,12 +32,21 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "jsdom": "^27.0.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^2.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -48,6 +60,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.6.1.tgz",
+      "integrity": "sha512-8QT9pokVe1fUt1C8IrJketaeFOdRfTOS96DL3EBjE8CRZm3eHnwMlQe2NPoOSEYPwJ5Q25uYoX1+m9044l3ysQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.2"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -283,6 +350,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -329,6 +406,144 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1695,6 +1910,104 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2076,6 +2389,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2097,6 +2496,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2180,6 +2589,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -2233,6 +2662,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2306,6 +2745,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2347,6 +2796,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2362,6 +2828,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2479,6 +2955,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2492,12 +2989,41 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2517,12 +3043,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2537,6 +3090,14 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2556,6 +3117,26 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2792,6 +3373,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2800,6 +3391,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3096,6 +3697,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3131,6 +3786,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -3205,6 +3870,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3256,6 +3928,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3372,6 +4084,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3381,6 +4100,34 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3404,6 +4151,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -3601,6 +4358,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3651,6 +4421,23 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3858,6 +4645,47 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3909,6 +4737,14 @@
       "peerDependencies": {
         "react": "^19.2.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3979,6 +4815,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4065,6 +4925,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4087,6 +4954,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4134,6 +5021,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4156,6 +5050,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4261,6 +5169,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4322,6 +5243,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tabbable": {
       "version": "6.2.0",
@@ -4400,6 +5328,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4448,6 +5390,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4459,6 +5451,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4677,6 +5695,519 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4708,6 +6239,649 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4722,6 +6896,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4828,6 +7019,45 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",
@@ -22,6 +23,9 @@
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@tailwindcss/forms": "^0.5.10",
+    "@testing-library/jest-dom": "^6.4.5",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^24.6.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
@@ -31,10 +35,12 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "jsdom": "^27.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^2.1.5"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { DashboardPage } from './pages/DashboardPage'
+import { BillingPage } from './pages/account/BillingPage'
+import { LimitsPage } from './pages/account/LimitsPage'
 import { SettingsPage } from './pages/SettingsPage'
 import { Spinner } from './components/ui/Spinner'
 
@@ -15,6 +17,8 @@ export function App() {
     >
       <Routes>
         <Route path="/" element={<DashboardPage />} />
+        <Route path="/account/billing" element={<BillingPage />} />
+        <Route path="/account/limits" element={<LimitsPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/components/account/SpendWarningBanner.tsx
+++ b/frontend/src/components/account/SpendWarningBanner.tsx
@@ -1,0 +1,35 @@
+import { ExclamationTriangleIcon, XMarkIcon } from '@heroicons/react/24/outline'
+
+import { clearSpendWarning, useSpendWarning } from '../../features/account/store'
+
+export function SpendWarningBanner() {
+  const { data } = useSpendWarning()
+
+  if (!data?.active) {
+    return null
+  }
+
+  return (
+    <div className="border border-amber-500/40 bg-amber-500/10 text-amber-100">
+      <div className="flex items-start justify-between gap-4 p-4">
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 rounded-full bg-amber-500/20 p-2 text-amber-300">
+            <ExclamationTriangleIcon className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold uppercase tracking-wide text-amber-200">Spend Limit Warning</p>
+            <p className="text-sm text-amber-100/90">{data.message}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => clearSpendWarning()}
+          className="rounded-md p-1 text-amber-200 transition hover:bg-amber-500/20 hover:text-white"
+          aria-label="Dismiss spending limit warning"
+        >
+          <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react'
+
+import { SpendWarningBanner } from '../account/SpendWarningBanner'
 import { Sidebar } from './Sidebar'
 
 export function AppShell({ children }: { children: ReactNode }) {
@@ -6,7 +8,10 @@ export function AppShell({ children }: { children: ReactNode }) {
     <div className="flex min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
       <Sidebar />
       <main className="flex-1 overflow-hidden">
-        <div className="flex min-h-screen flex-col">{children}</div>
+        <div className="flex min-h-screen flex-col">
+          <SpendWarningBanner />
+          <div className="flex-1">{children}</div>
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { NavLink } from 'react-router-dom'
 import { twMerge } from 'tailwind-merge'
-import { Squares2X2Icon, Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { Squares2X2Icon, Cog6ToothIcon, CreditCardIcon, ChartBarIcon } from '@heroicons/react/24/outline'
 
 const navItems = [
   { name: 'Dashboard', to: '/', icon: Squares2X2Icon },
+  { name: 'Billing', to: '/account/billing', icon: CreditCardIcon },
+  { name: 'Limits', to: '/account/limits', icon: ChartBarIcon },
   { name: 'Settings', to: '/settings', icon: Cog6ToothIcon },
 ]
 

--- a/frontend/src/features/account/api.ts
+++ b/frontend/src/features/account/api.ts
@@ -1,0 +1,62 @@
+import {
+  AccountLimitsResponse,
+  AccountLimitsUpdateRequest,
+  AccountPlanResponse,
+  AccountPlanUpdateRequest,
+  ApiError,
+  apiClient,
+} from '../../lib/api'
+import { CAP_WARNING_MESSAGE } from './constants'
+import { clearSpendWarning, setSpendWarning } from './store'
+
+function handleWarning(flag?: string | null, capReached?: boolean) {
+  if (flag === 'cap_reached' || capReached) {
+    setSpendWarning(CAP_WARNING_MESSAGE)
+  } else if (!capReached) {
+    clearSpendWarning()
+  }
+}
+
+function normalizeCap(value: string | number): string {
+  const numeric = typeof value === 'string' ? Number(value) : value
+  if (Number.isNaN(numeric) || numeric < 0) {
+    return '0.00'
+  }
+  return numeric.toFixed(2)
+}
+
+export async function fetchAccountPlan(): Promise<AccountPlanResponse> {
+  const { data, warning } = await apiClient.getAccountPlan()
+  handleWarning(warning)
+  return data
+}
+
+export async function updateAccountPlan(payload: AccountPlanUpdateRequest): Promise<AccountPlanResponse> {
+  const { data, warning } = await apiClient.updateAccountPlan(payload)
+  handleWarning(warning)
+  return data
+}
+
+export async function fetchAccountLimits(): Promise<AccountLimitsResponse> {
+  const { data, warning } = await apiClient.getAccountLimits()
+  handleWarning(warning, data.cap_reached)
+  return data
+}
+
+export async function updateAccountLimits(
+  payload: AccountLimitsUpdateRequest,
+): Promise<AccountLimitsResponse> {
+  try {
+    const { data, warning } = await apiClient.updateAccountLimits({
+      ...payload,
+      monthly_cap_usd: normalizeCap(payload.monthly_cap_usd),
+    })
+    handleWarning(warning, data.cap_reached)
+    return data
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 402) {
+      setSpendWarning(CAP_WARNING_MESSAGE)
+    }
+    throw error
+  }
+}

--- a/frontend/src/features/account/constants.ts
+++ b/frontend/src/features/account/constants.ts
@@ -1,0 +1,2 @@
+export const CAP_WARNING_MESSAGE =
+  'Your monthly spending limit has been reached. Adjust your limit to continue.';

--- a/frontend/src/features/account/hooks.ts
+++ b/frontend/src/features/account/hooks.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import {
+  fetchAccountLimits,
+  fetchAccountPlan,
+  updateAccountLimits,
+  updateAccountPlan,
+} from './api'
+import { AccountLimitsResponse, AccountPlanResponse } from '../../lib/api'
+
+export function useAccountPlan() {
+  return useQuery<AccountPlanResponse>({
+    queryKey: ['account', 'plan'],
+    queryFn: fetchAccountPlan,
+  })
+}
+
+export function useUpdateAccountPlan() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: updateAccountPlan,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['account', 'plan'], data)
+    },
+  })
+}
+
+export function useAccountLimits() {
+  return useQuery<AccountLimitsResponse>({
+    queryKey: ['account', 'limits'],
+    queryFn: fetchAccountLimits,
+  })
+}
+
+export function useUpdateAccountLimits() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: updateAccountLimits,
+    onSuccess: (data) => {
+      queryClient.setQueryData(['account', 'limits'], data)
+    },
+  })
+}

--- a/frontend/src/features/account/store.ts
+++ b/frontend/src/features/account/store.ts
@@ -1,0 +1,39 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { queryClient } from '../../lib/queryClient'
+import { CAP_WARNING_MESSAGE } from './constants'
+
+export type SpendWarningState = {
+  active: boolean
+  message: string
+}
+
+const SPEND_WARNING_KEY = ['account', 'spend-warning'] as const
+const DEFAULT_WARNING: SpendWarningState = { active: false, message: '' }
+
+export function getSpendWarningState(): SpendWarningState {
+  return (queryClient.getQueryData(SPEND_WARNING_KEY) as SpendWarningState | undefined) ?? DEFAULT_WARNING
+}
+
+export function setSpendWarning(message: string = CAP_WARNING_MESSAGE) {
+  queryClient.setQueryData<SpendWarningState>(SPEND_WARNING_KEY, { active: true, message })
+}
+
+export function clearSpendWarning() {
+  queryClient.setQueryData<SpendWarningState>(SPEND_WARNING_KEY, DEFAULT_WARNING)
+}
+
+export function useSpendWarning() {
+  const client = useQueryClient()
+  return useQuery({
+    queryKey: SPEND_WARNING_KEY,
+    queryFn: () => getSpendWarningState(),
+    initialData: () => getSpendWarningState(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+    meta: { source: 'spend-warning' },
+    onSuccess: (data) => {
+      client.setQueryData(SPEND_WARNING_KEY, data)
+    },
+  })
+}

--- a/frontend/src/pages/account/BillingPage.tsx
+++ b/frontend/src/pages/account/BillingPage.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from 'react'
+
+import { useAccountPlan, useUpdateAccountPlan } from '../../features/account/hooks'
+import { CAP_WARNING_MESSAGE } from '../../features/account/constants'
+import { AppShell } from '../../components/layout/AppShell'
+import { Header } from '../../components/layout/Header'
+import { Spinner } from '../../components/ui/Spinner'
+import type { AccountPlanResponse } from '../../lib/api'
+import { ApiError } from '../../lib/api'
+
+const PLAN_OPTIONS: Array<{
+  code: AccountPlanResponse['plan']
+  title: string
+  price: string
+  description: string
+  features: string[]
+}> = [
+  {
+    code: 'FREE',
+    title: 'Free',
+    price: '$0/mo',
+    description: 'Foundational access for prototyping and occasional automations.',
+    features: ['Community support', 'Shared queue access', 'Usage analytics (basic)'],
+  },
+  {
+    code: 'PRO',
+    title: 'Pro',
+    price: '$99/mo',
+    description: 'Priority execution windows, deeper analytics, and premium support.',
+    features: ['Priority scheduling', 'Advanced usage analytics', 'Dedicated support channel'],
+  },
+]
+
+export function BillingPage() {
+  const { data: currentPlan, isLoading } = useAccountPlan()
+  const updatePlan = useUpdateAccountPlan()
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const activePlan = useMemo(() => currentPlan?.plan, [currentPlan])
+
+  const handleSelect = (code: AccountPlanResponse['plan']) => {
+    if (code === activePlan || updatePlan.isPending) {
+      return
+    }
+    setStatusMessage(null)
+    setErrorMessage(null)
+    updatePlan.mutate(
+      { plan: code },
+      {
+        onSuccess: (data) => {
+          setStatusMessage(`Plan updated to ${data.name}`)
+        },
+        onError: (error) => {
+          if (error instanceof ApiError) {
+            if (error.status === 402) {
+              setErrorMessage(CAP_WARNING_MESSAGE)
+              return
+            }
+            setErrorMessage(error.message)
+          } else {
+            setErrorMessage('Unable to update plan right now. Please try again.')
+          }
+        },
+      },
+    )
+  }
+
+  return (
+    <AppShell>
+      <Header
+        title="Billing Plan"
+        description="Choose the subscription tier that matches your team’s automation workload."
+      />
+      <div className="flex-1 p-6">
+        {isLoading ? (
+          <div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-950/40">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {statusMessage && (
+              <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+                {statusMessage}
+              </div>
+            )}
+            {errorMessage && (
+              <div className="rounded-xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+                {errorMessage}
+              </div>
+            )}
+            <div className="grid gap-4 md:grid-cols-2">
+              {PLAN_OPTIONS.map((plan) => {
+                const isActive = plan.code === activePlan
+                const isPending = updatePlan.isPending && updatePlan.variables?.plan === plan.code
+                return (
+                  <button
+                    key={plan.code}
+                    type="button"
+                    onClick={() => handleSelect(plan.code)}
+                    disabled={isPending}
+                    aria-label={`${plan.title} plan option`}
+                    className={`group flex h-full flex-col justify-between rounded-2xl border p-6 text-left transition
+                      ${
+                        isActive
+                          ? 'border-sky-400/70 bg-sky-500/10 text-white shadow-lg shadow-sky-900/40'
+                          : 'border-slate-800/70 bg-slate-950/50 hover:border-sky-500/50 hover:bg-slate-900/60'
+                      } ${isPending ? 'opacity-70' : ''}`}
+                  >
+                    <div className="space-y-4">
+                      <div>
+                        <p className="text-sm font-semibold uppercase tracking-wider text-slate-400">{plan.title}</p>
+                        <p className="mt-2 text-3xl font-bold text-white">{plan.price}</p>
+                        <p className="mt-2 text-sm text-slate-300">{plan.description}</p>
+                      </div>
+                      <ul className="space-y-2 text-sm text-slate-300">
+                        {plan.features.map((feature) => (
+                          <li key={feature} className="flex items-center gap-2">
+                            <span className="h-1.5 w-1.5 rounded-full bg-sky-400" aria-hidden="true" />
+                            {feature}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="mt-6">
+                      <span
+                        className={`inline-flex items-center rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-wide transition
+                          ${
+                            isActive
+                              ? 'bg-sky-500/20 text-sky-200'
+                              : 'bg-slate-800/70 text-slate-200 group-hover:bg-sky-500/20 group-hover:text-sky-100'
+                          }`}
+                      >
+                        {isActive ? 'Current Plan' : isPending ? 'Updating…' : 'Select Plan'}
+                      </span>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+export default BillingPage

--- a/frontend/src/pages/account/LimitsPage.tsx
+++ b/frontend/src/pages/account/LimitsPage.tsx
@@ -1,0 +1,179 @@
+import { FormEvent, useEffect, useState } from 'react'
+
+import { useAccountLimits, useUpdateAccountLimits } from '../../features/account/hooks'
+import { CAP_WARNING_MESSAGE } from '../../features/account/constants'
+import { AppShell } from '../../components/layout/AppShell'
+import { Header } from '../../components/layout/Header'
+import { Spinner } from '../../components/ui/Spinner'
+import { ApiError } from '../../lib/api'
+
+function formatCurrency(value: string) {
+  const number = Number(value)
+  if (Number.isNaN(number)) {
+    return '$0.00'
+  }
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(number)
+}
+
+export function LimitsPage() {
+  const { data, isLoading } = useAccountLimits()
+  const updateLimits = useUpdateAccountLimits()
+  const [capInput, setCapInput] = useState('0.00')
+  const [hardStop, setHardStop] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (data) {
+      setCapInput(data.monthly_cap_usd)
+      setHardStop(Boolean(data.hard_stop))
+    }
+  }, [data])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setStatusMessage(null)
+    setErrorMessage(null)
+    updateLimits.mutate(
+      { monthly_cap_usd: capInput, hard_stop: hardStop },
+      {
+        onSuccess: (payload) => {
+          setCapInput(payload.monthly_cap_usd)
+          setHardStop(Boolean(payload.hard_stop))
+          setStatusMessage('Spending limits updated successfully.')
+        },
+        onError: (error) => {
+          if (error instanceof ApiError) {
+            if (error.status === 402) {
+              setErrorMessage(CAP_WARNING_MESSAGE)
+              return
+            }
+            setErrorMessage(error.message)
+          } else {
+            setErrorMessage('Unable to update limits right now. Please try again.')
+          }
+        },
+      },
+    )
+  }
+
+  return (
+    <AppShell>
+      <Header
+        title="Usage Limits"
+        description="Manage monthly spend ceilings, set hard stops, and review current usage before launching more work."
+      />
+      <div className="flex-1 p-6">
+        {isLoading ? (
+          <div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-950/40">
+            <Spinner size="lg" />
+          </div>
+        ) : (
+          <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+            <form
+              onSubmit={handleSubmit}
+              className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-950/50 p-6 shadow-inner shadow-slate-900/40"
+            >
+              <div>
+                <label htmlFor="monthly-cap" className="text-sm font-medium text-slate-200">
+                  Monthly spending cap (USD)
+                </label>
+                <div className="mt-2 flex items-center gap-3">
+                  <span className="rounded-lg bg-slate-900 px-3 py-2 text-sm text-slate-400">USD</span>
+                  <input
+                    id="monthly-cap"
+                    name="monthly_cap_usd"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    value={capInput}
+                    onChange={(event) => setCapInput(event.target.value)}
+                    className="flex-1 rounded-lg border border-slate-800 bg-slate-950/80 px-3 py-2 text-sm text-white outline-none transition focus:border-sky-500"
+                  />
+                </div>
+                <p className="mt-2 text-xs text-slate-400">
+                  Set to 0.00 to allow usage only when triggered by administrators.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-between rounded-xl border border-slate-800/60 bg-slate-900/50 p-4">
+                <div>
+                  <p className="text-sm font-semibold text-slate-200">Hard stop when cap reached</p>
+                  <p className="text-xs text-slate-400">
+                    When enabled, workflows pause immediately once spending hits the configured cap.
+                  </p>
+                </div>
+                <label className="relative inline-flex cursor-pointer items-center">
+                  <input
+                    type="checkbox"
+                    checked={hardStop}
+                    onChange={(event) => setHardStop(event.target.checked)}
+                    className="peer sr-only"
+                  />
+                  <div className="peer h-6 w-11 rounded-full bg-slate-700 transition peer-checked:bg-sky-500">
+                    <div className="h-5 w-5 translate-x-0.5 rounded-full bg-white transition peer-checked:translate-x-5" />
+                  </div>
+                </label>
+              </div>
+
+              {statusMessage && (
+                <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+                  {statusMessage}
+                </div>
+              )}
+              {errorMessage && (
+                <div className="rounded-xl border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+                  {errorMessage}
+                </div>
+              )}
+
+              <button
+                type="submit"
+                disabled={updateLimits.isPending}
+                className="inline-flex items-center justify-center rounded-xl bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {updateLimits.isPending ? 'Saving…' : 'Save limits'}
+              </button>
+            </form>
+
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-slate-800/60 bg-slate-950/50 p-6 shadow-inner shadow-slate-900/40">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Current month</h3>
+                <div className="mt-4 space-y-3 text-sm">
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-400">Used</span>
+                    <span className="font-semibold text-white">{formatCurrency(data?.usage_usd ?? '0')}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-400">Cap</span>
+                    <span className="font-semibold text-white">{formatCurrency(data?.monthly_cap_usd ?? '0')}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-slate-400">Remaining</span>
+                    <span className="font-semibold text-white">{formatCurrency(data?.remaining_usd ?? '0')}</span>
+                  </div>
+                </div>
+                {data?.cap_reached && (
+                  <p className="mt-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+                    {data.hard_stop
+                      ? 'Hard stop is enabled. New jobs will be blocked until limits are adjusted.'
+                      : 'Soft warning active. New jobs may continue, but additional spend will exceed your configured cap.'}
+                  </p>
+                )}
+              </div>
+              <div className="rounded-2xl border border-slate-800/60 bg-slate-950/40 p-6 text-xs text-slate-400">
+                <p className="font-semibold text-slate-200">Forecast guidance</p>
+                <p className="mt-2">
+                  Budgets refresh at the start of each UTC calendar month. Adjust your cap if upcoming releases are expected to
+                  increase workload volume.
+                </p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+export default LimitsPage

--- a/frontend/src/pages/account/__tests__/BillingPage.test.tsx
+++ b/frontend/src/pages/account/__tests__/BillingPage.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+vi.mock('../../../features/account/hooks', () => ({
+  useAccountPlan: vi.fn(),
+  useUpdateAccountPlan: vi.fn(),
+}))
+
+import { useAccountPlan, useUpdateAccountPlan } from '../../../features/account/hooks'
+import { queryClient } from '../../../lib/queryClient'
+import { BillingPage } from '../BillingPage'
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const useAccountPlanMock = useAccountPlan as unknown as Mock
+const useUpdateAccountPlanMock = useUpdateAccountPlan as unknown as Mock
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  queryClient.clear()
+})
+
+test('renders plans and updates selection', async () => {
+  const user = userEvent.setup()
+  useAccountPlanMock.mockReturnValue({
+    data: { plan: 'FREE', name: 'Free', monthly_price_usd: '0.00' },
+    isLoading: false,
+  })
+
+  const result = { mutate: vi.fn(), isPending: false, variables: undefined as any }
+  result.mutate.mockImplementation((payload, options) => {
+    result.variables = payload
+    options?.onSuccess?.({ plan: payload.plan, name: payload.plan === 'PRO' ? 'Pro' : 'Free', monthly_price_usd: '0.00' })
+  })
+  useUpdateAccountPlanMock.mockReturnValue(result)
+
+  renderWithProviders(<BillingPage />)
+
+  expect(screen.getByText('Free')).toBeInTheDocument()
+  const proCard = screen.getByRole('button', { name: /pro plan option/i })
+  await user.click(proCard)
+
+  expect(result.mutate).toHaveBeenCalledWith(
+    { plan: 'PRO' },
+    expect.objectContaining({
+      onSuccess: expect.any(Function),
+      onError: expect.any(Function),
+    }),
+  )
+  expect(screen.getByText('Plan updated to Pro')).toBeInTheDocument()
+})

--- a/frontend/src/pages/account/__tests__/LimitsPage.test.tsx
+++ b/frontend/src/pages/account/__tests__/LimitsPage.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import type { Mock } from 'vitest'
+import { vi } from 'vitest'
+
+vi.mock('../../../features/account/hooks', () => ({
+  useAccountLimits: vi.fn(),
+  useUpdateAccountLimits: vi.fn(),
+}))
+
+import { useAccountLimits, useUpdateAccountLimits } from '../../../features/account/hooks'
+import { setSpendWarning } from '../../../features/account/store'
+import { queryClient } from '../../../lib/queryClient'
+import { CAP_WARNING_MESSAGE } from '../../../features/account/constants'
+import { LimitsPage } from '../LimitsPage'
+import { ApiError } from '../../../lib/api'
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+const useAccountLimitsMock = useAccountLimits as unknown as Mock
+const useUpdateAccountLimitsMock = useUpdateAccountLimits as unknown as Mock
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  queryClient.clear()
+})
+
+test('renders limits and submits updates', async () => {
+  const user = userEvent.setup()
+  useAccountLimitsMock.mockReturnValue({
+    data: {
+      monthly_cap_usd: '120.00',
+      hard_stop: false,
+      usage_usd: '45.00',
+      remaining_usd: '75.00',
+      cap_reached: false,
+    },
+    isLoading: false,
+  })
+  const result = { mutate: vi.fn(), isPending: false }
+  result.mutate.mockImplementation((payload, options) => {
+    options?.onSuccess?.({
+      monthly_cap_usd: '200.00',
+      hard_stop: true,
+      usage_usd: '45.00',
+      remaining_usd: '155.00',
+      cap_reached: false,
+    })
+  })
+  useUpdateAccountLimitsMock.mockReturnValue(result)
+
+  renderWithProviders(<LimitsPage />)
+
+  const input = screen.getByLabelText(/monthly spending cap/i)
+  await user.clear(input)
+  await user.type(input, '200')
+  await user.click(screen.getByRole('checkbox'))
+  await user.click(screen.getByRole('button', { name: /save limits/i }))
+
+  expect(result.mutate).toHaveBeenCalledWith(
+    { monthly_cap_usd: '200', hard_stop: true },
+    expect.any(Object),
+  )
+  expect(screen.getByText('Spending limits updated successfully.')).toBeInTheDocument()
+})
+
+test('shows exact warning copy when cap reached error occurs', async () => {
+  const user = userEvent.setup()
+  useAccountLimitsMock.mockReturnValue({
+    data: {
+      monthly_cap_usd: '50.00',
+      hard_stop: true,
+      usage_usd: '50.00',
+      remaining_usd: '0.00',
+      cap_reached: true,
+    },
+    isLoading: false,
+  })
+  const result = { mutate: vi.fn(), isPending: false }
+  result.mutate.mockImplementation((_payload, options) => {
+    options?.onError?.(new ApiError(CAP_WARNING_MESSAGE, 402))
+  })
+  useUpdateAccountLimitsMock.mockReturnValue(result)
+
+  renderWithProviders(<LimitsPage />)
+
+  await user.click(screen.getByRole('button', { name: /save limits/i }))
+  expect(screen.getByText(CAP_WARNING_MESSAGE)).toBeInTheDocument()
+})
+
+test('renders global banner when warning state active', () => {
+  useAccountLimitsMock.mockReturnValue({
+    data: {
+      monthly_cap_usd: '10.00',
+      hard_stop: false,
+      usage_usd: '10.00',
+      remaining_usd: '0.00',
+      cap_reached: true,
+    },
+    isLoading: false,
+  })
+  useUpdateAccountLimitsMock.mockReturnValue({ mutate: vi.fn(), isPending: false })
+
+  setSpendWarning(CAP_WARNING_MESSAGE)
+  renderWithProviders(<LimitsPage />)
+  expect(screen.getByText(/Spend Limit Warning/i)).toBeInTheDocument()
+  expect(screen.getByText(CAP_WARNING_MESSAGE)).toBeInTheDocument()
+})

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,4 +28,10 @@ export default defineConfig({
       },
     },
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    css: true,
+  },
 })

--- a/tests/backend/account/test_account_api.py
+++ b/tests/backend/account/test_account_api.py
@@ -1,0 +1,152 @@
+import asyncio
+import os
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import asyncio
+import os
+from decimal import Decimal
+from pathlib import Path
+
+import fakeredis.aioredis
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("JWT_ACTIVE_KID", "current")
+os.environ.setdefault("JWT_PRIVATE_KEYS_DIR", str(Path(__file__).resolve().parent))
+os.environ.setdefault("TURNSTILE_SECRET_KEY", "test-key")
+os.environ.setdefault("CELERY_BROKER_URL", "memory://")
+os.environ.setdefault("EMAIL_FROM_ADDRESS", "noreply@example.com")
+os.environ.setdefault("FRONTEND_BASE_URL", "https://frontend.example.com")
+os.environ.setdefault("API_BASE_URL", "https://api.example.com")
+os.environ.setdefault("EMAIL_VERIFICATION_SECRET", "secret")
+os.environ.setdefault("ADMIN_EMAIL", "admin@example.com")
+os.environ.setdefault("ADMIN_PASSWORD", "password123!")
+
+from backend.account.api import router as account_router
+from backend.account.dependencies import get_redis
+from backend.account.services import SpendAccountingService
+from backend.auth.api.deps import require_current_user
+from backend.core.config import get_settings
+from backend.db.base import Base
+from backend.db.models.billing import Plan
+from backend.db.models.user import User, UserStatus
+from backend.db.session import get_db
+
+
+@pytest.fixture
+def account_app(settings_env):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine, expire_on_commit=False, future=True, class_=Session)
+    session = TestingSession()
+
+    fake_redis = fakeredis.aioredis.FakeRedis()
+
+    user = User(
+        id=uuid4(),
+        email="user@example.com",
+        status=UserStatus.ACTIVE,
+        password_hash="hash",
+    )
+    plan_free = Plan(id=uuid4(), code="FREE", name="Free", monthly_price_usd=Decimal("0.00"))
+    plan_pro = Plan(id=uuid4(), code="PRO", name="Pro", monthly_price_usd=Decimal("99.00"))
+    session.add_all([user, plan_free, plan_pro])
+    session.commit()
+
+    app = FastAPI()
+    app.include_router(account_router)
+
+    async def override_get_redis():
+        return fake_redis
+
+    def override_get_db():
+        yield session
+
+    async def override_current_user():
+        return user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_current_user] = override_current_user
+    app.dependency_overrides[get_settings] = lambda: settings_env
+    app.dependency_overrides[get_redis] = override_get_redis
+
+    client = TestClient(app)
+
+    yield client, session, user, fake_redis
+
+    client.close()
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+    asyncio.run(fake_redis.aclose())
+
+
+def test_plan_and_limits_flow(account_app):
+    client, session, user, _ = account_app
+
+    response = client.get("/v1/account/plan")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["plan"] == "FREE"
+
+    response = client.post("/v1/account/plan", json={"plan": "PRO"})
+    assert response.status_code == 200
+    assert response.json()["plan"] == "PRO"
+
+    response = client.post("/v1/account/limits", json={"monthly_cap_usd": "250.00", "hard_stop": False})
+    assert response.status_code == 200
+
+    response = client.get("/v1/account/limits")
+    assert response.status_code == 200
+    limits = response.json()
+    assert limits["monthly_cap_usd"] == "250.00"
+    assert limits["hard_stop"] is False
+    assert limits["usage_usd"] == "0.00"
+    assert limits["remaining_usd"] == "250.00"
+
+
+def test_warning_header_emitted(account_app):
+    client, session, user, _ = account_app
+
+    client.post("/v1/account/limits", json={"monthly_cap_usd": "10.00", "hard_stop": False})
+    accounting = SpendAccountingService(session)
+    accounting.record(user.id, Decimal("10.00"), meta={"reason": "usage"})
+    session.commit()
+
+    response = client.get("/v1/account/limits")
+    assert response.headers.get("X-Spend-Warning") == "cap_reached"
+    body = response.json()
+    assert body["cap_reached"] is True
+    assert body["remaining_usd"] == "0.00"
+
+
+def test_rate_limit_enforced(account_app):
+    client, _, __, fake_redis = account_app
+
+    for _ in range(5):
+        assert client.post("/v1/account/plan", json={"plan": "PRO"}).status_code == 200
+
+    response = client.post("/v1/account/plan", json={"plan": "PRO"})
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Rate limit exceeded. Please try again later."
+
+    asyncio.run(fake_redis.flushall())
+
+    for _ in range(10):
+        assert client.post("/v1/account/limits", json={"monthly_cap_usd": "50.00", "hard_stop": False}).status_code == 200
+
+    response = client.post("/v1/account/limits", json={"monthly_cap_usd": "50.00", "hard_stop": False})
+    assert response.status_code == 429
+    assert response.json()["detail"] == "Rate limit exceeded. Please try again later."

--- a/tests/backend/account/test_spend_service.py
+++ b/tests/backend/account/test_spend_service.py
@@ -1,0 +1,155 @@
+import os
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+from uuid import uuid4
+
+import os
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://user:pass@localhost:5432/testdb")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("JWT_ACTIVE_KID", "current")
+os.environ.setdefault("JWT_PRIVATE_KEYS_DIR", str(Path(__file__).resolve().parent))
+os.environ.setdefault("TURNSTILE_SECRET_KEY", "test-key")
+os.environ.setdefault("CELERY_BROKER_URL", "memory://")
+os.environ.setdefault("EMAIL_FROM_ADDRESS", "noreply@example.com")
+os.environ.setdefault("FRONTEND_BASE_URL", "https://frontend.example.com")
+os.environ.setdefault("API_BASE_URL", "https://api.example.com")
+os.environ.setdefault("EMAIL_VERIFICATION_SECRET", "secret")
+os.environ.setdefault("ADMIN_EMAIL", "admin@example.com")
+os.environ.setdefault("ADMIN_PASSWORD", "password123!")
+
+from backend.account.enforcement import CAP_BLOCK_MESSAGE, enforce_spend_cap
+from backend.account.schemas import PlanCode
+from backend.account.services import PlanService, SpendAccountingService, SpendLimitService
+from backend.db.base import Base
+from backend.db.models.audit import AuditLog
+from backend.db.models.billing import Plan
+from backend.db.models.user import User, UserStatus
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        future=True,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine, expire_on_commit=False, future=True, class_=Session)
+    db = TestingSession()
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def user(session: Session):
+    usr = User(id=uuid4(), email="acct@example.com", status=UserStatus.ACTIVE, password_hash="hash")
+    session.add(usr)
+    plan_free = Plan(id=uuid4(), code="FREE", name="Free", monthly_price_usd=Decimal("0.00"))
+    plan_pro = Plan(id=uuid4(), code="PRO", name="Pro", monthly_price_usd=Decimal("99.00"))
+    session.add_all([plan_free, plan_pro])
+    session.commit()
+    return usr
+
+
+def test_record_and_totals(session: Session, user: User):
+    accounting = SpendAccountingService(session)
+    limits = SpendLimitService(session)
+    limits.update_limits(
+        user_id=user.id,
+        monthly_cap_usd=Decimal("50.00"),
+        hard_stop=False,
+        actor_user_id=user.id,
+        ip=None,
+        user_agent=None,
+    )
+    accounting.record(user.id, Decimal("10.25"), meta={"job_id": "job-1"})
+    accounting.record(user.id, Decimal("5.75"), meta=None)
+    session.commit()
+
+    totals = accounting.get_month_totals(user.id)
+    assert totals.usage_usd == Decimal("16.00")
+    assert totals.remaining_usd == Decimal("34.00")
+    assert totals.cap_reached is False
+
+
+def test_enforce_spend_cap(session: Session, user: User):
+    limits = SpendLimitService(session)
+    limits.update_limits(
+        user_id=user.id,
+        monthly_cap_usd=Decimal("20.00"),
+        hard_stop=True,
+        actor_user_id=user.id,
+        ip=None,
+        user_agent=None,
+    )
+    accounting = SpendAccountingService(session)
+    accounting.record(user.id, Decimal("20.00"), meta=None)
+    session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        enforce_spend_cap(user.id, Decimal("1.00"), session=session)
+    assert exc.value.status_code == 402
+    assert exc.value.detail == CAP_BLOCK_MESSAGE
+
+    limits.update_limits(
+        user_id=user.id,
+        monthly_cap_usd=Decimal("30.00"),
+        hard_stop=False,
+        actor_user_id=user.id,
+        ip=None,
+        user_agent=None,
+    )
+    session.commit()
+    result = enforce_spend_cap(user.id, Decimal("15.00"), session=session, raise_on_block=False)
+    assert result.cap_reached is True
+    assert result.hard_stop is False
+    assert result.warning_header == "cap_reached"
+
+
+def test_audit_events_emitted(session: Session, user: User):
+    plan_service = PlanService(session)
+    limit_service = SpendLimitService(session)
+    accounting = SpendAccountingService(session)
+
+    plan_service.set_plan(
+        user_id=user.id,
+        plan_code=PlanCode.PRO,
+        actor_user_id=user.id,
+        ip="203.0.113.10",
+        user_agent="pytest",
+    )
+    limit_service.update_limits(
+        user_id=user.id,
+        monthly_cap_usd=Decimal("100.00"),
+        hard_stop=False,
+        actor_user_id=user.id,
+        ip="203.0.113.10",
+        user_agent="pytest",
+    )
+    accounting.record(user.id, Decimal("42.00"), meta={"source": "unit-test"})
+    accounting.enforce_cap(
+        user_id=user.id,
+        estimated_usd=Decimal("80.00"),
+        actor_user_id=user.id,
+        ip="203.0.113.10",
+        user_agent="pytest",
+    )
+    session.commit()
+
+    actions = {row.action for row in session.execute(select(AuditLog)).scalars()}
+    assert {"plan_changed", "limits_changed", "spend_recorded", "cap_reached"}.issubset(actions)


### PR DESCRIPTION
## Summary
- add account plan and limits FastAPI routes with spend enforcement, audit events, and Redis-backed rate limits
- introduce spend accounting services, Alembic migration for spend records, orchestrator hook, and backend test coverage
- deliver billing and limits React pages with API store wiring, warning banner, vitest suites, and supporting setup updates

## Testing
- `pytest tests/backend/account -q`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68e3eeb53e54832d9de16a413457efc2