### PR TITLE
Rename audit metadata column and configure frontend alias

### DIFF
--- a/alembic/versions/202510081530_rename_audit_event_metadata_column.py
+++ b/alembic/versions/202510081530_rename_audit_event_metadata_column.py
@@ -1,0 +1,22 @@
+"""rename audit event metadata column
+
+Revision ID: 202510081530
+Revises: 202510081500
+Create Date: 2025-10-08 15:30:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202510081530"
+down_revision = "202510081500"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("audit_events", "metadata", new_column_name="event_metadata")
+
+
+def downgrade() -> None:
+    op.alter_column("audit_events", "event_metadata", new_column_name="metadata")

--- a/backend/audit/schemas.py
+++ b/backend/audit/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AuditEventSchema(BaseModel):
@@ -17,7 +17,7 @@ class AuditEventSchema(BaseModel):
     action: str
     resource_type: str | None
     resource_id: UUID | None
-    metadata: dict[str, Any] | None
+    metadata: dict[str, Any] | None = Field(default=None, alias="event_metadata")
     ip_address: str | None
     user_agent: str | None
     created_at: datetime
@@ -25,8 +25,7 @@ class AuditEventSchema(BaseModel):
     # Include actor email for display
     actor_email: str | None = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class AuditEventListResponse(BaseModel):

--- a/backend/audit/service.py
+++ b/backend/audit/service.py
@@ -45,7 +45,7 @@ def create_audit_event(
         action=action,
         resource_type=resource_type,
         resource_id=resource_id,
-        metadata=metadata or {},
+        event_metadata=metadata or {},
         ip_address=ip_address,
         user_agent=user_agent,
         created_at=datetime.utcnow(),

--- a/backend/db/models/audit_event.py
+++ b/backend/db/models/audit_event.py
@@ -38,7 +38,7 @@ class AuditEvent(Base):
     resource_id = Column(UUID(as_uuid=True), nullable=True, index=True)
 
     # Additional context
-    metadata = Column(JSONB, nullable=True)
+    event_metadata = Column("event_metadata", JSONB, nullable=True)
     # Store action-specific data: {'old_plan': 'free', 'new_plan': 'pro'}
 
     # Request context

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@heroicons/react": "^2.2.0",
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-query-devtools": "^5.90.2",
+        "date-fns": "^4.1.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.3",
@@ -3024,6 +3025,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@heroicons/react": "^2.2.0",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-query-devtools": "^5.90.2",
+    "date-fns": "^4.1.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.3",

--- a/frontend/src/pages/billing/PaymentHistoryPage.tsx
+++ b/frontend/src/pages/billing/PaymentHistoryPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
+import { Card } from '@/components/ui/Card'
 import { usePaymentHistory } from '@/features/billing/hooks'
-import { Card } from '@/components/ui/card'
 import { formatDistanceToNow } from 'date-fns'
 
 export default function PaymentHistoryPage() {
@@ -16,21 +16,6 @@ export default function PaymentHistoryPage() {
       style: 'currency',
       currency: currency.toUpperCase(),
     }).format(amount)
-  }
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'succeeded':
-        return 'text-green-400'
-      case 'pending':
-        return 'text-yellow-400'
-      case 'failed':
-        return 'text-red-400'
-      case 'refunded':
-        return 'text-gray-400'
-      default:
-        return 'text-gray-400'
-    }
   }
 
   const getStatusBadgeColor = (status: string) => {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -12,6 +12,10 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "noEmit": true,
     "jsx": "react-jsx",
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,16 @@
+import { fileURLToPath, URL } from 'node:url'
+
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   server: {
     proxy: {
       '/v1': {


### PR DESCRIPTION
## Summary
- rename the AuditEvent SQLAlchemy attribute to event_metadata and provide a migration to rename the underlying column
- update audit schemas and service helpers to reference the new attribute while preserving metadata payloads
- configure Vite/TypeScript to resolve the @ alias, fix the payment history page imports, and add date-fns for relative timestamps

## Testing
- pytest tests/backend/admin/test_admin_api.py::test_update_roles_emits_audit *(fails: missing fakeredis dependency in environment)*
- npm run build *(fails: existing ApiClient type mismatch errors in subscription/billing code)*

------
https://chatgpt.com/codex/tasks/task_e_68e65f268e98832db9ffadb9b61f46cb